### PR TITLE
feat: Implement cookie-based interface choice

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
     <link rel="stylesheet" type="text/css" href="styles/tooltip.css">
     <link rel="stylesheet" id="pagestyle" href="styles/yotsubluenew.715.css">
     <link rel="stylesheet" href="styles/xa24extra.css">
+    <link rel="stylesheet" href="styles/cookie-banner.css">
     <link rel="icon" href="assets/images/blapu-logo.png" type="image/png">
 </head>
 <body >
@@ -825,5 +826,11 @@
             <div id="bottom"></div>
         </div>
         <script src="scripts/app.js"></script>
+
+        <div id="cookie-banner">
+            <p>Choose your experience: Would you like to use the old interface or try our new simple UI?</p>
+            <button id="cookie-old-btn">Old Interface</button>
+            <button id="cookie-new-btn">New Interface</button>
+        </div>
     </body>
 </html>

--- a/new-ui.html
+++ b/new-ui.html
@@ -1,0 +1,164 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Blapu - New UI</title>
+    <meta name="description" content="Blapu: New simplified UI with Vestige widgets.">
+    <link rel="icon" href="assets/images/blapu-logo.png" type="image/png">
+    <style>
+        body {
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+            margin: 0;
+            padding: 0;
+            background: linear-gradient(135deg, #6dd5ed, #2193b0);
+            color: #fff;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            min-height: 100vh;
+            overflow-x: hidden; /* Prevent horizontal scroll */
+        }
+
+        .container {
+            width: 90%;
+            max-width: 1000px;
+            margin-top: 30px;
+            margin-bottom: 30px;
+            padding: 25px;
+            background: rgba(255, 255, 255, 0.1); /* Translucent white */
+            backdrop-filter: blur(15px) saturate(180%);
+            -webkit-backdrop-filter: blur(15px) saturate(180%); /* For Safari */
+            border-radius: 15px;
+            border: 1px solid rgba(209, 213, 219, 0.3); /* Light border */
+            box-shadow: 0 8px 32px 0 rgba(31, 38, 135, 0.37);
+            text-align: center;
+        }
+
+        h1 {
+            font-size: 2.5em;
+            margin-bottom: 15px;
+            color: #f0f0f0;
+            text-shadow: 2px 2px 4px rgba(0,0,0,0.2);
+        }
+
+        p {
+            font-size: 1.1em;
+            line-height: 1.6;
+            margin-bottom: 25px;
+            color: #e0e0e0;
+        }
+
+        .widget-container {
+            display: flex;
+            flex-direction: column; /* Stack widgets vertically on small screens */
+            gap: 20px; /* Space between widgets */
+            margin-top: 20px;
+        }
+
+        .widget {
+            background: rgba(255, 255, 255, 0.05); /* Slightly more transparent */
+            backdrop-filter: blur(10px) saturate(150%);
+            -webkit-backdrop-filter: blur(10px) saturate(150%);
+            border-radius: 10px;
+            padding: 15px;
+            border: 1px solid rgba(209, 213, 219, 0.2);
+            box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
+            height: 400px; /* Default height, can be adjusted */
+            width: 100%; /* Full width of container */
+        }
+
+        .widget iframe {
+            width: 100%;
+            height: 100%;
+            border: none;
+            border-radius: 8px; /* Match widget's border radius */
+        }
+
+        /* Responsive adjustments */
+        @media (min-width: 768px) {
+            .widget-container {
+                flex-direction: row; /* Widgets side-by-side on larger screens */
+            }
+            .widget {
+                height: 650px; /* Taller widgets on larger screens */
+            }
+        }
+
+        .footer-nav {
+            margin-top: 30px;
+            padding: 15px;
+            background: rgba(0, 0, 0, 0.2);
+            border-radius: 10px;
+            width: fit-content;
+        }
+
+        .footer-nav a {
+            color: #fff;
+            text-decoration: none;
+            padding: 8px 15px;
+            border-radius: 5px;
+            transition: background-color 0.3s ease;
+        }
+
+        .footer-nav a:hover {
+            background-color: rgba(255, 255, 255, 0.2);
+        }
+
+    </style>
+</head>
+<body>
+    <div class="container">
+        <img src="assets/images/blapu-logo.png" alt="Blapu Logo" style="width: 100px; height: 100px; margin-bottom: 20px;">
+        <h1>Welcome to the New Blapu Interface!</h1>
+        <p>
+            This simplified view focuses on providing you with direct access to key Blapu information and trading tools via Vestige.
+            Below you'll find the Blapu asset chart and a swap widget to easily trade.
+        </p>
+
+        <div class="widget-container">
+            <div class="widget">
+                <iframe
+                    id="vestige-chart-iframe"
+                    title="Vestige Chart Widget"
+                    src="https://vestige.fi/widget/401752010/chart?interval=1W&tools=true&currency=USD"
+                ></iframe>
+            </div>
+            <div class="widget">
+                <iframe
+                    id="vestige-swap-iframe"
+                    title="Vestige Swap Widget"
+                    src="https://vestige.fi/widget/swap?asset_in=0&asset_out=401752010"
+                ></iframe>
+            </div>
+        </div>
+         <div class="footer-nav">
+            <a href="index.html" id="go-to-old-ui">Return to Full Site (Old UI)</a>
+        </div>
+    </div>
+
+    <script>
+        // Script to handle returning to old UI and clearing the choice
+        const goToOldUiButton = document.getElementById('go-to-old-ui');
+
+        function setCookie(name, value, days) {
+            let expires = "";
+            if (days) {
+                const date = new Date();
+                date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000));
+                expires = "; expires=" + date.toUTCString();
+            }
+            document.cookie = name + "=" + (value || "") + expires + "; path=/";
+        }
+
+        if (goToOldUiButton) {
+            goToOldUiButton.addEventListener('click', (event) => {
+                event.preventDefault(); // Prevent default link behavior before cookie is set
+                setCookie('siteChoice', 'old', 30); // Set choice to 'old'
+                // The 'siteChoiceMade' cookie remains 'yes'
+                window.location.href = 'index.html';
+            });
+        }
+    </script>
+</body>
+</html>

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -215,4 +215,73 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // Call formatGreentext for existing posts
   formatGreentext();
+
+  // --- Cookie Banner Logic ---
+  const cookieBanner = document.getElementById('cookie-banner');
+  const oldInterfaceBtn = document.getElementById('cookie-old-btn');
+  const newInterfaceBtn = document.getElementById('cookie-new-btn');
+
+  function setCookie(name, value, days) {
+    let expires = "";
+    if (days) {
+      const date = new Date();
+      date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000));
+      expires = "; expires=" + date.toUTCString();
+    }
+    document.cookie = name + "=" + (value || "") + expires + "; path=/";
+  }
+
+  function getCookie(name) {
+    const nameEQ = name + "=";
+    const ca = document.cookie.split(';');
+    for (let i = 0; i < ca.length; i++) {
+      let c = ca[i];
+      while (c.charAt(0) == ' ') c = c.substring(1, c.length);
+      if (c.indexOf(nameEQ) == 0) return c.substring(nameEQ.length, c.length);
+    }
+    return null;
+  }
+
+  function showCookieBanner() {
+    if (!getCookie('siteChoiceMade')) {
+      if (cookieBanner) {
+        cookieBanner.style.display = 'block';
+      }
+    } else {
+      // If choice is already made, and it was 'new', redirect to new-ui.html
+      // This handles the case where the user revisits index.html after choosing 'new'
+      if (getCookie('siteChoice') === 'new' && window.location.pathname !== '/new-ui.html') {
+        window.location.href = 'new-ui.html';
+      }
+    }
+  }
+
+  if (oldInterfaceBtn) {
+    oldInterfaceBtn.addEventListener('click', () => {
+      setCookie('siteChoiceMade', 'yes', 30);
+      setCookie('siteChoice', 'old', 30);
+      if (cookieBanner) {
+        cookieBanner.style.display = 'none';
+      }
+      // No redirect needed, user stays on current page.
+      // Potentially apply 'old' style if it's different from current,
+      // but for now, it just hides the banner.
+    });
+  }
+
+  if (newInterfaceBtn) {
+    newInterfaceBtn.addEventListener('click', () => {
+      setCookie('siteChoiceMade', 'yes', 30);
+      setCookie('siteChoice', 'new', 30);
+      if (cookieBanner) {
+        cookieBanner.style.display = 'none';
+      }
+      window.location.href = 'new-ui.html'; // Redirect to the new UI page
+    });
+  }
+
+  // Show banner on page load (if not on new-ui.html itself, to avoid banner loop)
+  if (cookieBanner && window.location.pathname.indexOf('new-ui.html') === -1) {
+    showCookieBanner();
+  }
 });

--- a/styles/cookie-banner.css
+++ b/styles/cookie-banner.css
@@ -1,0 +1,44 @@
+#cookie-banner {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    background-color: #333;
+    color: white;
+    padding: 15px;
+    text-align: center;
+    z-index: 1000; /* Ensure it's above other content */
+    border-top: 1px solid #555;
+    display: none; /* Initially hidden, JS will show it */
+}
+
+#cookie-banner p {
+    margin: 0 0 10px 0;
+    font-size: 1em;
+}
+
+#cookie-banner button {
+    background-color: #5cb85c;
+    color: white;
+    border: none;
+    padding: 10px 20px;
+    text-align: center;
+    text-decoration: none;
+    display: inline-block;
+    font-size: 1em;
+    margin: 5px;
+    cursor: pointer;
+    border-radius: 5px;
+}
+
+#cookie-banner button:hover {
+    background-color: #4cae4c;
+}
+
+#cookie-banner button#cookie-old-btn {
+    background-color: #f0ad4e;
+}
+
+#cookie-banner button#cookie-old-btn:hover {
+    background-color: #ec971f;
+}


### PR DESCRIPTION
Adds a cookie banner allowing users to choose between the old interface and a new simplified UI.

- Banner displayed on first visit or until a choice is made.
- 'Old Interface' button keeps the user on the current site.
- 'New Interface' button redirects to 'new-ui.html'.
- 'new-ui.html' provides a liquid glass design with Vestige widgets and a link to return to the old interface.
- User's choice is stored in a cookie and respected on subsequent visits. If 'new' was chosen, accessing index.html will redirect to new-ui.html.