### PR TITLE
refactor: Simplify Blapu dancer for more cartoonish background effect

### DIFF
--- a/new-ui.html
+++ b/new-ui.html
@@ -26,28 +26,28 @@
             }
         }
 
-        @keyframes detailedCripWalk {
+        @keyframes detailedCripWalk { /* Main body movement */
             0% { transform: translateX(-48vw) translateY(0px) rotate(0deg); }
-            20% { transform: translateX(-28vw) translateY(-20px) rotate(-8deg) scaleX(0.95); }
+            20% { transform: translateX(-28vw) translateY(-15px) rotate(-7deg) scaleX(0.98); }
             25% { transform: translateX(-22vw) translateY(0px) rotate(0deg) scaleX(1); }
-            40% { transform: translateX(12vw) translateY(-20px) rotate(8deg) scaleX(0.95); }
+            40% { transform: translateX(12vw) translateY(-15px) rotate(7deg) scaleX(0.98); }
             45% { transform: translateX(18vw) translateY(0px) rotate(0deg) scaleX(1); }
-            60% { transform: translateX(38vw) translateY(-15px) rotate(-5deg) scaleX(0.95); }
+            60% { transform: translateX(38vw) translateY(-12px) rotate(-4deg) scaleX(0.98); }
             65% { transform: translateX(42vw) translateY(0px) rotate(0deg) scaleX(1); }
-            80% { transform: translateX(8vw) translateY(-18px) rotate(6deg) scaleX(0.95); }
+            80% { transform: translateX(8vw) translateY(-14px) rotate(5deg) scaleX(0.98); }
             85% { transform: translateX(2vw) translateY(0px) rotate(0deg) scaleX(1); }
             100% { transform: translateX(-48vw) translateY(0px) rotate(0deg); }
         }
 
-        @keyframes dancerArmSwing {
-            0%, 100% { transform: rotate(15deg); }
-            50% { transform: rotate(-25deg); }
+        @keyframes simpleArmSwing {
+            0%, 100% { transform: rotate(25deg); }
+            50% { transform: rotate(-35deg); }
         }
-        @keyframes dancerLegSwing {
-            0%, 100% { transform: rotate(-10deg) translateY(0px) ; }
-            25% { transform: rotate(10deg) translateY(-10px); } /* Lift */
-            50% { transform: rotate(20deg) translateY(5px); } /* Forward step */
-            75% { transform: rotate(-5deg) translateY(-5px); } /* Back lift */
+        @keyframes simpleLegSwing {
+            0%, 100% { transform: rotate(-15deg) translateY(0px); }
+            25% { transform: rotate(5deg) translateY(-8px); }
+            50% { transform: rotate(25deg) translateY(3px); }
+            75% { transform: rotate(-0deg) translateY(-4px); }
         }
 
 
@@ -65,22 +65,22 @@
             position: relative;
         }
 
-        #animated-blapu-bg { /* Container for all background animations */
+        #animated-blapu-bg {
             position: fixed;
             top: 0;
             left: 0;
             width: 100%;
             height: 100%;
-            z-index: -2; /* Behind .blapu-dancer now */
+            z-index: -2;
             overflow: hidden;
             background: linear-gradient(135deg, #1a2a6c, #b21f1f, #fdbb2d);
         }
 
         .blapu-blob {
             position: absolute;
-            background: radial-gradient(circle at center, rgba(0, 123, 255, 0.4), rgba(0, 80, 180, 0.6)); /* More subdued */
-            opacity: 0.5; /* More subdued */
-            filter: blur(8px); /* More blur as they are further back */
+            background: radial-gradient(circle at center, rgba(0, 123, 255, 0.4), rgba(0, 80, 180, 0.6));
+            opacity: 0.5;
+            filter: blur(8px);
             border-radius: 40% 60% 70% 30% / 40% 50% 60% 50%;
         }
 
@@ -88,247 +88,124 @@
         .blob-2 { top: 55%; left: 75%; width: 220px; height: 250px; animation: dance 15s infinite ease-in-out alternate; animation-delay: -7s; opacity: 0.35;}
         .blob-3 { top: 25%; left: 45%; width: 180px; height: 170px; animation: dance 25s infinite ease-in-out alternate; animation-delay: -12s; opacity: 0.45;}
 
-        /* --- Detailed Blapu Dancer --- */
+        /* --- Simplified Blapu Dancer --- */
         .blapu-dancer {
             position: absolute;
             bottom: 2%;
             left: 50%;
-            width: 225px; /* Increased by ~50% from 150px */
-            height: 300px;/* Increased by ~50% from 200px */
-            z-index: -2; /* Same plane as blobs, behind glass */
+            width: 225px;
+            height: 300px;
+            z-index: -2; /* Same plane as blobs */
             animation: detailedCripWalk 15s infinite linear;
             transform-style: preserve-3d;
-            filter: blur(4px); /* Increased blur for a more hazy effect */
+            filter: blur(4px); /* Base blur, increased from 1px */
         }
 
-        .dancer-head {
+        .dancer-main-body { /* Combined head and torso into one main shape */
             position: absolute;
-            width: 120px; /* Proportional to new dancer size */
-            height: 100px;
+            width: 130px;
+            height: 180px;
             background-color: #2453d1; /* Deep blue */
             border: 4px solid #000;
-            border-radius: 50% 50% 40% 40% / 60% 60% 45% 45%; /* More oval head */
-            top: 0;
-            left: 52.5px; /* (225 - 120) / 2 */
-            z-index: 10;
+            /* More of a pear or Blapu-like shape */
+            border-radius: 50% 50% 45% 45% / 65% 65% 35% 35%;
+            top: 10px; /* Position within .blapu-dancer */
+            left: calc(50% - 65px); /* Centered */
+            z-index: 5;
         }
-        /* Ears using pseudo-elements */
-        .dancer-head::before, .dancer-head::after {
+
+        /* Simplified Ears - part of main body's ::before/::after */
+        .dancer-main-body::before, .dancer-main-body::after {
             content: '';
+            position: absolute;
+            width: 50px;
+            height: 60px;
+            background-color: #2453d1;
+            border: 4px solid #000;
+            border-bottom: none; /* Ears are part of head, so no bottom border */
+            border-radius: 60% 60% 10px 10px / 100% 100% 10px 10px; /* Simpler ear shape */
+            top: -30px; /* Position on top of head */
+            z-index: -1; /* Behind main body's border */
+        }
+        .dancer-main-body::before { /* Left ear */
+            left: -5px;
+            transform: rotate(-25deg);
+        }
+        .dancer-main-body::after { /* Right ear */
+            right: -5px;
+            transform: rotate(25deg);
+        }
+
+        .dancer-eye-simple { /* Simplified eyes */
             position: absolute;
             width: 40px;
             height: 50px;
-            background-color: #2453d1;
-            border: 4px solid #000;
-            border-radius: 50% 50% 0 0 / 80% 80% 0 0; /* Protruding rounded ear shape */
-            top: -25px; /* Position on top of head */
+            background-color: #fff;
+            border: 3px solid #000;
+            border-radius: 50%;
+            top: 30px; /* On the main body */
         }
-        .dancer-head::before { /* Left ear */
-            left: -10px;
-            transform: rotate(-15deg);
-        }
-        .dancer-head::after { /* Right ear */
-            right: -10px;
-            transform: rotate(15deg);
-        }
-        /* Inner ear highlights */
-        .ear-highlight-left, .ear-highlight-right {
+        .dancer-eye-simple.left { left: 20px; transform: rotate(-8deg); }
+        .dancer-eye-simple.right { right: 20px; transform: rotate(8deg); }
+
+        .dancer-pupil-simple { /* Simplified pupil */
+            width: 18px;
+            height: 18px;
+            background-color: #000;
+            border-radius: 50%;
             position: absolute;
-            width: 20px;
+            top: calc(50% - 9px); /* Centered or slightly off */
+            left: calc(50% - 9px);
+        }
+
+        .dancer-mouth-simple { /* Simplified mouth */
+            position: absolute;
+            width: 60px;
             height: 25px;
-            background-color: #f47ab7; /* Pink */
-            border-radius: 50% 50% 0 0 / 80% 80% 0 0;
-            top: -18px;
-        }
-        .ear-highlight-left { left: 0px; transform: rotate(-15deg); }
-        .ear-highlight-right { right: 0px; transform: rotate(15deg); }
-
-
-        .eyes-container {
-            position: absolute;
-            width: 100%;
-            top: 25px; /* Position eyes on head */
-            display: flex;
-            justify-content: space-around;
-            padding: 0 15px;
-            box-sizing: border-box;
-        }
-        .eye {
-            width: 35px; /* Large oval eyes */
-            height: 45px;
-            background-color: #fff;
-            border: 2px solid #000;
-            border-radius: 50%;
-            position: relative;
-            overflow: hidden; /* To contain pupil */
-        }
-        .eye.left { transform: rotate(-5deg); }
-        .eye.right { transform: rotate(5deg); }
-
-        .pupil {
-            width: 15px;
-            height: 15px;
-            background-color: #000;
-            border-radius: 50%;
-            position: absolute;
-            top: 15px; /* Position pupil */
-            left: 10px;
-        }
-        .pupil-highlight {
-            width: 5px;
-            height: 5px;
-            background-color: #fff;
-            border-radius: 50%;
-            position: absolute;
-            top: 3px;
-            left: 3px;
-        }
-        .eyebrows {
-            position: absolute;
-            width: 100%;
-            top: 10px;
-        }
-        .eyebrow {
-            width: 40px;
-            height: 8px;
-            background-color: #000;
-            position: absolute;
-            border-radius: 4px;
-        }
-        .eyebrow.left { left: 15px; transform: rotate(-10deg); }
-        .eyebrow.right { right: 15px; transform: rotate(10deg); }
-
-        .mouth {
-            position: absolute;
-            width: 70px;
-            height: 35px;
+            border: 3px solid #000;
             background-color: #e15ba7; /* Pink lips */
-            border: 3px solid #000;
-            border-radius: 0 0 50% 50% / 0 0 100% 100%; /* Curved lower lip */
-            bottom: -5px; /* Position below eyes on head */
-            left: calc(50% - 35px);
-            overflow: hidden;
-        }
-        .mouth-line { /* Black mouth line */
-            width: 100%;
-            height: 5px;
-            background-color: #000;
-            position: absolute;
-            top: 10px; /* Adjust for smirk */
-            border-radius: 5px;
+            /* Simple curve, or a D shape for open mouth */
+            border-radius: 0 0 30px 30px / 0 0 100% 100%;
+            bottom: 25px; /* On the main body */
+            left: calc(50% - 30px);
         }
 
-
-        .dancer-torso {
+        /* Simplified Limbs */
+        .dancer-limb {
             position: absolute;
-            width: 110px;
-            height: 130px;
-            background-color: #2453d1; /* Blue base */
-            border: 4px solid #000;
-            border-radius: 30% 30% 50% 50% / 50% 50% 40% 40%; /* Torso shape */
-            top: 85px; /* Below head */
-            left: 57.5px; /* (225-110)/2 */
-            z-index: 5;
-        }
-        .shirt {
-            position: absolute;
-            width: 100%;
-            height: 70%; /* Covers part of torso */
-            background-color: #222; /* Black shirt */
-            top: 0;
-            left: 0;
-            border-radius: इन्हेरिट; /* Inherit parent's rounding for top part */
-             border-bottom: 4px solid #000; /* If shirt has its own outline */
-        }
-        /* Stylized 'A' logo for Algorand */
-        .shirt-logoA {
-            position: absolute;
-            top: 20%;
-            left: 50%;
-            transform: translateX(-50%);
-            width: 20px;
-            height: 25px;
-        }
-        .shirt-logoA::before, .shirt-logoA::after { /* Two skewed bars for 'A' */
-            content: '';
-            position: absolute;
-            width: 6px;
-            height: 100%;
-            background-color: white;
-        }
-        .shirt-logoA::before { left: 0; transform: skewX(-20deg); }
-        .shirt-logoA::after { right: 0; transform: skewX(20deg); }
-        /* Cross-bar for 'A' */
-        .shirt-logoA-bar {
-            position: absolute;
-            width: 100%;
-            height: 5px;
-            background-color: white;
-            top: 50%;
-            transform: translateY(-50%);
-        }
-
-
-        .dancer-arm, .dancer-leg {
-            position: absolute;
-            background-color: #2453d1; /* Blue limbs */
-            border: 3px solid #000;
-            z-index: 4; /* Behind torso slightly if overlapping */
-        }
-        .dancer-arm {
-            width: 35px; /* Proportional */
-            height: 90px;
-            border-radius: 20px;
-            transform-origin: center 15px; /* Shoulder */
-        }
-        .dancer-arm.left { top: 95px; left: 25px; animation: dancerArmSwing 3s infinite ease-in-out alternate -0.2s; }
-        .dancer-arm.right { top: 95px; right: 25px; animation: dancerArmSwing 3s infinite ease-in-out alternate; }
-
-        .hand {
-            width: 40px;
-            height: 40px;
             background-color: #2453d1;
             border: 3px solid #000;
-            border-radius: 40% 40% 50% 50%; /* Mitten shape */
-            position: absolute;
-            bottom: -15px; /* Attach to arm end */
-            left: -2.5px;
+            border-radius: 25px; /* Tubular limbs */
+            z-index: 4;
         }
-        /* Suggestion of fingers */
-        .hand::before, .hand::after {
-            content: '';
-            position: absolute;
-            width: 8px;
-            height: 15px;
-            background-color: #000; /* Part of outline */
-            border-radius: 4px;
-            top: 5px;
-        }
-        .hand::before { left: 8px; }
-        .hand::after { right: 8px; }
-
-
-        .dancer-leg {
+        .dancer-arm-simple {
             width: 40px;
             height: 100px;
-            border-radius: 20px 20px 15px 15px;
-            transform-origin: center 15px; /* Hip */
+            transform-origin: center 20px; /* Shoulder */
         }
-        .dancer-leg.left { top: 190px; left: 50px; animation: dancerLegSwing 2s infinite ease-in-out -0.1s; }
-        .dancer-leg.right { top: 190px; right: 50px; animation: dancerLegSwing 2s infinite ease-in-out; }
-
-        .foot {
-            width: 50px;
-            height: 30px;
-            background-color: #000; /* Black shoes */
-            border-radius: 10px 10px 15px 15px;
-            position: absolute;
-            bottom: -5px;
-            left: -5px;
+        .dancer-arm-simple.left {
+            top: 70px; left: 0px; /* Attach to side of main body */
+            animation: simpleArmSwing 3s infinite ease-in-out alternate -0.2s;
+        }
+        .dancer-arm-simple.right {
+            top: 70px; right: 0px;
+            animation: simpleArmSwing 3s infinite ease-in-out alternate;
         }
 
-        /* --- End Detailed Blapu Dancer --- */
-
+        .dancer-leg-simple {
+            width: 45px;
+            height: 110px;
+            transform-origin: center 20px; /* Hip */
+        }
+        .dancer-leg-simple.left {
+            top: 160px; left: 30px; /* Attach below main body */
+            animation: simpleLegSwing 2s infinite ease-in-out -0.1s;
+        }
+        .dancer-leg-simple.right {
+            top: 160px; right: 30px;
+            animation: simpleLegSwing 2s infinite ease-in-out;
+        }
+        /* --- End Simplified Blapu Dancer --- */
 
         .glass-panel {
             width: 90%;
@@ -340,7 +217,7 @@
             z-index: 1;
             position: relative;
             background: rgba(255, 255, 255, 0.05);
-            backdrop-filter: blur(10px) saturate(140%); /* Increased blur for dancer behind */
+            backdrop-filter: blur(10px) saturate(140%);
             -webkit-backdrop-filter: blur(10px) saturate(140%);
             border-radius: 1.5rem;
             border: 1px solid rgba(255, 255, 255, 0.2);
@@ -479,14 +356,14 @@
             align-self: center;
         }
 
-        @media (max-width: 520px) { /* Slightly larger breakpoint for hero stacking */
+        @media (max-width: 520px) {
             .hero-header {
                 flex-direction: column;
                 align-items: center;
                 gap: 15px;
             }
             .hero-header .blapu-logo-link { order: 1; }
-            .hero-header .hero-link { order: 2; flex-basis: auto; text-align: center; width: 90%; } /* Wider links when stacked */
+            .hero-header .hero-link { order: 2; flex-basis: auto; text-align: center; width: 90%; }
             .hero-header .hero-link.pact-link { order: 0; }
             .hero-header .hero-link.powapp-link { order: 2; }
 
@@ -497,17 +374,16 @@
             }
             .footer-nav .separator { display: none; }
             .blapu-dancer {
-                width: 180px; height: 240px; /* Adjusted responsive dancer size */
-                filter: blur(5px); /* Increased blur for smaller dancer */
+                width: 180px; height: 240px;
+                filter: blur(5px); /* Increased from 2px */
             }
         }
-         @media (max-width: 380px) { /* For very small screens */
+         @media (max-width: 380px) {
             .blapu-dancer {
                 width: 150px; height: 200px;
-                 filter: blur(6px); /* Increased blur for very small dancer */
+                filter: blur(6px); /* Increased from 2.5px */
             }
          }
-
 
     </style>
 </head>
@@ -517,44 +393,21 @@
         <div class="blapu-blob blob-2"></div>
         <div class="blapu-blob blob-3"></div>
         <div class="blapu-dancer">
-            <div class="dancer-head">
-                <div class="ear-highlight-left"></div>
-                <div class="ear-highlight-right"></div>
-                <div class="eyebrows">
-                    <div class="eyebrow left"></div>
-                    <div class="eyebrow right"></div>
+            <div class="dancer-main-body">
+                <!-- Simplified eyes directly on main body -->
+                <div class="dancer-eye-simple left">
+                    <div class="dancer-pupil-simple"></div>
                 </div>
-                <div class="eyes-container">
-                    <div class="eye left">
-                        <div class="pupil"><div class="pupil-highlight"></div></div>
-                    </div>
-                    <div class="eye right">
-                        <div class="pupil"><div class="pupil-highlight"></div></div>
-                    </div>
+                <div class="dancer-eye-simple right">
+                    <div class="dancer-pupil-simple"></div>
                 </div>
-                <div class="mouth">
-                    <div class="mouth-line"></div>
-                </div>
+                <div class="dancer-mouth-simple"></div>
             </div>
-            <div class="dancer-torso">
-                <div class="shirt">
-                    <div class="shirt-logoA">
-                        <div class="shirt-logoA-bar"></div>
-                    </div>
-                </div>
-            </div>
-            <div class="dancer-arm left">
-                <div class="hand"></div>
-            </div>
-            <div class="dancer-arm right">
-                <div class="hand"></div>
-            </div>
-            <div class="dancer-leg left">
-                <div class="foot"></div>
-            </div>
-            <div class="dancer-leg right">
-                <div class="foot"></div>
-            </div>
+            <!-- Simplified limbs directly attached to .blapu-dancer or .dancer-main-body -->
+            <div class="dancer-limb dancer-arm-simple left"></div>
+            <div class="dancer-limb dancer-arm-simple right"></div>
+            <div class="dancer-limb dancer-leg-simple left"></div>
+            <div class="dancer-limb dancer-leg-simple right"></div>
         </div>
     </div>
 


### PR DESCRIPTION
Simplifies the Blapu dancer character in `new-ui.html` to achieve a more iconic, broadly cartoonish look with fewer fine details, making it more suitable as a heavily blurred background element.

- **Reduced Detail:** HTML structure and CSS were revised to use fewer, simpler shapes for the head, face (eyes, mouth), body, and limbs. Intricate details like individual hands/feet, complex lip outlines, brows, and shirt/logo have been removed.
- **Styling:** Focused on broader cartoonish forms with thick outlines and core Blapu colors.
- **Animation:** Adapted limb animations to the simpler structure while retaining the main body's slow, smooth, wide-traversing 'crip walk' animation.

This change aims to make the dancer blend more effectively into the hazy, far-background aesthetic.