### PR TITLE
refactor: Significantly increase blur on Blapu dancer

### DIFF
--- a/new-ui.html
+++ b/new-ui.html
@@ -98,7 +98,7 @@
             z-index: -2; /* Same plane as blobs */
             animation: detailedCripWalk 15s infinite linear;
             transform-style: preserve-3d;
-            filter: blur(4px); /* Base blur, increased from 1px */
+            filter: blur(10px); /* Significantly increased blur */
         }
 
         .dancer-main-body { /* Combined head and torso into one main shape */
@@ -375,13 +375,13 @@
             .footer-nav .separator { display: none; }
             .blapu-dancer {
                 width: 180px; height: 240px;
-                filter: blur(5px); /* Increased from 2px */
+                filter: blur(12px); /* Significantly increased blur for smaller screens */
             }
         }
          @media (max-width: 380px) {
             .blapu-dancer {
                 width: 150px; height: 200px;
-                filter: blur(6px); /* Increased from 2.5px */
+                filter: blur(14px); /* Even more blur for very small screens */
             }
          }
 


### PR DESCRIPTION
Further increases the `filter: blur()` applied to the `.blapu-dancer` element in `new-ui.html` to achieve a very hazy, abstract cartoon effect for the background animation.

- Base blur increased from 4px to 10px.
- Blur in media queries for smaller screens increased proportionally (up to 14px).

This change ensures the dancer is heavily blurred, pushing it visually deep into the background and aligning with the request for a 'really blurry' appearance.