### PR TITLE
refactor: Polish new UI with lighter dancer blur and updated font

### DIFF
--- a/new-ui.html
+++ b/new-ui.html
@@ -52,7 +52,7 @@
 
 
         body {
-            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
             margin: 0;
             padding: 10px 20px;
             color: #fff;
@@ -98,7 +98,7 @@
             height: 325px; /* 650px * 0.5 */
             z-index: -2;
             animation: detailedCripWalk 15s infinite linear;
-            filter: blur(10px);
+            filter: blur(6px); /* Lightened blur */
         }
 
         .blapu-dancer .head {
@@ -513,14 +513,14 @@
             .blapu-dancer {
                 width: 180px;
                 height: 234px; /* Adjusted for 650px original height aspect ratio (180 * 650/500) */
-                filter: blur(12px);
+                filter: blur(7px); /* Lightened blur for medium screens */
             }
         }
          @media (max-width: 380px) {
             .blapu-dancer {
                 width: 150px;
                 height: 195px; /* (150 * 650/500) */
-                filter: blur(14px);
+                filter: blur(8px); /* Lightened blur for small screens */
             }
          }
 


### PR DESCRIPTION
Applies final polishing touches to `new-ui.html`:

- **Lighter Dancer Blur:** Reduced the `filter: blur()` values on the animated Blapu dancer (base 6px, responsive 7-8px). This makes the character's form slightly more discernible while ensuring it remains a soft, out-of-focus background element.
- **Updated Font Stack:** Changed the primary `font-family` for the page to prioritize system UI fonts (e.g., -apple-system, BlinkMacSystemFont) for a more modern, Apple-like typographic feel, with appropriate sans-serif fallbacks.
- **Centering & Glass Effect Review:** Confirmed that content centering remains effective and the existing detailed liquid glass effects for panels and buttons contribute to a premium aesthetic. No CSS changes were made to these aspects in this commit.