### PR TITLE
refactor: Overhaul Blapu dancer animation to rhythmic hip-hop style

### DIFF
--- a/new-ui.html
+++ b/new-ui.html
@@ -26,43 +26,53 @@
             }
         }
 
-        @keyframes detailedCripWalk {
-            0% { transform: translateX(-48vw) translateY(0px) rotate(0deg) scaleX(1); } /* Start Left */
+        @keyframes detailedCripWalk { /* Rhythmic Hip-Hop Style */
+            /* Centered around X=0vw, Y=0px. Range approx +/- 10vw for steps */
+            /* Total 16 steps in this sequence example to make a fuller loop */
+            0%  { transform: translate(0vw, 0px) scale(1) rotate(0deg); } /* Start Center, normal */
 
-            /* Phase 1: Move right with a dip */
-            15% { transform: translateX(-25vw) translateY(5px) rotate(-5deg) scaleX(0.98); } /* Dip down */
-            20% { transform: translateX(-20vw) translateY(0px) rotate(0deg) scaleX(1); } /* Smooth out */
+            /* 2 steps left */
+            6%  { transform: translate(-5vw, -10px) scale(1.02) rotate(-3deg); } /* Step L1 + Bob Up + Pop */
+            12% { transform: translate(-4vw, 0px) scale(1) rotate(0deg); }      /* Land L1 */
+            18% { transform: translate(-10vw, -12px) scale(1.03) rotate(-5deg); }/* Step L2 + Bob Up + Pop */
+            24% { transform: translate(-8vw, 0px) scale(1) rotate(0deg); }     /* Land L2 */
 
-            /* Phase 2: Jump and Flip (Spin) */
-            30% { transform: translateX(0vw) translateY(-60px) rotate(0deg) scaleX(1); } /* Wind up for jump */
-            35% { transform: translateX(5vw) translateY(-120px) rotate(180deg) scaleX(1.05); } /* Apex of jump, mid-flip */
-            40% { transform: translateX(10vw) translateY(-60px) rotate(360deg) scaleX(1); } /* Coming down from flip */
-            45% { transform: translateX(15vw) translateY(0px) rotate(360deg) scaleX(1); } /* Land */
+            /* 1 step right */
+            30% { transform: translate(-3vw, -10px) scale(1.02) rotate(3deg); } /* Step R1 + Bob Up + Pop */
+            36% { transform: translate(-4vw, 0px) scale(1) rotate(0deg); }     /* Land R1 */
 
-            /* Phase 3: Move further right with style */
-            55% { transform: translateX(35vw) translateY(-20px) rotate(8deg) scaleX(0.97); } /* Stylish lean */
-            60% { transform: translateX(42vw) translateY(0px) rotate(0deg) scaleX(1); } /* Smooth out far right */
+            /* Pause/Groove */
+            36%, 49% { transform: translate(-4vw, 0px) scale(1) rotate(0deg); } /* Hold */
 
-            /* Phase 4: Move back left with a dip */
-            75% { transform: translateX(10vw) translateY(10px) rotate(-6deg) scaleX(0.98); } /* Dip down while moving left */
-            80% { transform: translateX(0vw) translateY(0px) rotate(0deg) scaleX(1); } /* Smooth out center */
+            /* 2 steps right */
+            50% { transform: translate(0vw, 0px) scale(1) rotate(0deg); }      /* Center, normal */
+            56% { transform: translate(5vw, -10px) scale(1.02) rotate(3deg); }  /* Step R1 + Bob Up + Pop */
+            62% { transform: translate(4vw, 0px) scale(1) rotate(0deg); }       /* Land R1 */
+            68% { transform: translate(10vw, -12px) scale(1.03) rotate(5deg); } /* Step R2 + Bob Up + Pop */
+            74% { transform: translate(8vw, 0px) scale(1) rotate(0deg); }      /* Land R2 */
 
-            95% { transform: translateX(-40vw) translateY(-10px) rotate(5deg) scaleX(1.02); } /* Nearing start */
-            100% { transform: translateX(-48vw) translateY(0px) rotate(0deg) scaleX(1); } /* End Left, loop */
+            /* 1 step left */
+            80% { transform: translate(3vw, -10px) scale(1.02) rotate(-3deg); } /* Step L1 + Bob Up + Pop */
+            86% { transform: translate(4vw, 0px) scale(1) rotate(0deg); }      /* Land L1 */
+
+            /* Pause/Groove */
+            86%, 99% { transform: translate(4vw, 0px) scale(1) rotate(0deg); } /* Hold */
+            100% { transform: translate(0vw, 0px) scale(1) rotate(0deg); }     /* End Center, loop */
         }
 
-        @keyframes blapuArmSwing { /* Applied to .arm elements - 3s duration */
-            0%, 100% { transform: rotate(20deg) translateY(-2px) scaleY(1); } /* Standard swing */
-            25% { transform: rotate(0deg) translateY(-10px) scaleY(0.8) scaleX(0.9); } /* Arms up/tuck for jump */
-            50% { transform: rotate(-15deg) translateY(0px) scaleY(1); } /* Standard swing */
-            75% { transform: rotate(10deg) translateY(-5px) scaleY(0.9) scaleX(0.95); } /* Another dynamic pose */
+        @keyframes blapuArmSwing { /* Hip-Hop Style Arms - 1.5s duration for quicker feel */
+            0%, 100% { transform: rotate(15deg) translateY(0px) scaleY(1); }
+            20% { transform: rotate(-10deg) translateY(-3px) scaleY(0.95); } /* Quick jab/pose */
+            40% { transform: rotate(25deg) translateY(2px) scaleY(1.05); }  /* Larger swing */
+            60% { transform: rotate(-5deg) translateY(0px) scaleY(1); }   /* Smaller recovery */
+            80% { transform: rotate(10deg) translateY(-2px) scaleY(0.9); }  /* Another pose */
         }
 
-        @keyframes blapuLegSwing { /* Applied to .leg elements - 2s duration */
-            0%, 100% { transform: rotate(-10deg) translateY(0px) scaleY(1) translateX(-1px); } /* Standard step */
-            25% { transform: rotate(0deg) translateY(-15px) scaleY(0.7) translateX(0px); }  /* Legs tuck up for jump */
-            50% { transform: rotate(10deg) translateY(2px) scaleY(1) translateX(1px); }   /* Standard step */
-            75% { transform: rotate(5deg) translateY(-10px) scaleY(0.8) translateX(0px); }  /* Another dynamic pose */
+        @keyframes blapuLegSwing { /* Hip-Hop Style Legs - 1s duration for quick steps */
+            0%, 100% { transform: rotate(-5deg) translateY(0px) scaleY(1) translateX(0px); } /* Base step */
+            25% { transform: rotate(5deg) translateY(-8px) scaleY(0.9) translateX(2px); }  /* Lift/Pop */
+            50% { transform: rotate(0deg) translateY(0px) scaleY(1.02) translateX(0px); }   /* Stomp/Pop */
+            75% { transform: rotate(-8deg) translateY(-5px) scaleY(0.95) translateX(-2px); }/* Another step variation */
         }
 
 
@@ -113,7 +123,7 @@
             height: 325px; /* 650px * 0.5 */
             z-index: -2;
             animation: detailedCripWalk 15s infinite linear;
-            filter: blur(9px); /* Increased blur again */
+            filter: blur(7px); /* Slightly reduced blur */
         }
 
         .blapu-dancer .head {
@@ -255,7 +265,7 @@
             border: 2px solid #000;
             z-index: 2;
             animation-name: blapuArmSwing;
-            animation-duration: 3s;
+            animation-duration: 1.5s; /* Quicker arm swing */
             animation-iteration-count: infinite;
             animation-timing-function: ease-in-out;
             animation-direction: alternate;
@@ -303,7 +313,7 @@
             background: #bdc3c7; /* Grey pants */
             border: 2px solid #000;
             animation-name: blapuLegSwing;
-            animation-duration: 2s; /* Example duration */
+            animation-duration: 1s; /* Quicker leg steps */
             animation-iteration-count: infinite;
             animation-timing-function: ease-in-out;
             transform-origin: center top;
@@ -528,14 +538,14 @@
             .blapu-dancer {
                 width: 180px;
                 height: 234px; /* Adjusted for 650px original height aspect ratio (180 * 650/500) */
-                filter: blur(10px); /* Increased blur for medium screens */
+                filter: blur(8px); /* Slightly reduced blur for medium screens */
             }
         }
          @media (max-width: 380px) {
             .blapu-dancer {
                 width: 150px;
                 height: 195px; /* (150 * 650/500) */
-                filter: blur(11px); /* Increased blur for small screens */
+                filter: blur(9px); /* Slightly reduced blur for small screens */
             }
          }
 


### PR DESCRIPTION
Transforms the Blapu dancer's animation in `new-ui.html` to a localized, rhythmic hip-hop dance style and slightly adjusts blur:

- **New Main Body Animation:** The `@keyframes detailedCripWalk` has been completely rewritten. It now features a '2 steps left, 1 step right' (and reverse) pattern with frequent bobbing (`translateY`) and popping (`scale`, `rotate`) effects, keeping the dancer in a more contained area.
- **Adapted Limb Animations:** `@blapuArmSwing` and `@blapuLegSwing` keyframes are updated with shorter, more energetic, and varied movements to match the new dance rhythm. Animation durations for limbs are reduced (arms to 1.5s, legs to 1s).
- **Slightly Reduced Blur:** The `filter: blur()` on the dancer has been slightly reduced (base 7px, responsive 8-9px) to make the new, more nuanced dance moves a bit more discernible while still maintaining a soft background appearance.

This overhaul aims to give Blapu a more engaging, rhythmic dance performance fitting a hip-hop vibe, rather than the previous wide-traversal and flip animation.