### PR TITLE
refactor: Widen Blapu dancer's horizontal range in animation

### DIFF
--- a/new-ui.html
+++ b/new-ui.html
@@ -27,36 +27,35 @@
         }
 
         @keyframes detailedCripWalk { /* Rhythmic Hip-Hop Style */
-            /* Centered around X=0vw, Y=0px. Range approx +/- 10vw for steps */
-            /* Total 16 steps in this sequence example to make a fuller loop */
-            0%  { transform: translate(0vw, 0px) scale(1) rotate(0deg); } /* Start Center, normal */
+            /* Centered around X=0vw, Y=0px. Wider range: approx +/- 28vw for steps */
+            0%  { transform: translate(0vw, 0px) scale(1) rotate(0deg); } /* Start Center */
 
-            /* 2 steps left */
-            6%  { transform: translate(-5vw, -10px) scale(1.02) rotate(-3deg); } /* Step L1 + Bob Up + Pop */
-            12% { transform: translate(-4vw, 0px) scale(1) rotate(0deg); }      /* Land L1 */
-            18% { transform: translate(-10vw, -12px) scale(1.03) rotate(-5deg); }/* Step L2 + Bob Up + Pop */
-            24% { transform: translate(-8vw, 0px) scale(1) rotate(0deg); }     /* Land L2 */
+            /* 2 steps left, wider */
+            6%  { transform: translate(-12vw, -10px) scale(1.02) rotate(-3deg); } /* Step L1 */
+            12% { transform: translate(-10vw, 0px) scale(1) rotate(0deg); }      /* Land L1 */
+            18% { transform: translate(-28vw, -12px) scale(1.03) rotate(-5deg); }/* Step L2 (far left) */
+            24% { transform: translate(-25vw, 0px) scale(1) rotate(0deg); }     /* Land L2 */
 
-            /* 1 step right */
-            30% { transform: translate(-3vw, -10px) scale(1.02) rotate(3deg); } /* Step R1 + Bob Up + Pop */
-            36% { transform: translate(-4vw, 0px) scale(1) rotate(0deg); }     /* Land R1 */
+            /* 1 step right, towards center */
+            30% { transform: translate(-10vw, -10px) scale(1.02) rotate(3deg); } /* Step R1 */
+            36% { transform: translate(-12vw, 0px) scale(1) rotate(0deg); }     /* Land R1 */
 
-            /* Pause/Groove */
-            36%, 49% { transform: translate(-4vw, 0px) scale(1) rotate(0deg); } /* Hold */
+            /* Pause/Groove near left-center */
+            36%, 49% { transform: translate(-12vw, 2px) scale(0.98) rotate(1deg); } /* Hold with slight dip/sway */
 
-            /* 2 steps right */
-            50% { transform: translate(0vw, 0px) scale(1) rotate(0deg); }      /* Center, normal */
-            56% { transform: translate(5vw, -10px) scale(1.02) rotate(3deg); }  /* Step R1 + Bob Up + Pop */
-            62% { transform: translate(4vw, 0px) scale(1) rotate(0deg); }       /* Land R1 */
-            68% { transform: translate(10vw, -12px) scale(1.03) rotate(5deg); } /* Step R2 + Bob Up + Pop */
-            74% { transform: translate(8vw, 0px) scale(1) rotate(0deg); }      /* Land R2 */
+            /* 2 steps right, wider */
+            50% { transform: translate(0vw, 0px) scale(1) rotate(0deg); }      /* Recenter */
+            56% { transform: translate(12vw, -10px) scale(1.02) rotate(3deg); }  /* Step R1 */
+            62% { transform: translate(10vw, 0px) scale(1) rotate(0deg); }       /* Land R1 */
+            68% { transform: translate(28vw, -12px) scale(1.03) rotate(5deg); } /* Step R2 (far right) */
+            74% { transform: translate(25vw, 0px) scale(1) rotate(0deg); }      /* Land R2 */
 
-            /* 1 step left */
-            80% { transform: translate(3vw, -10px) scale(1.02) rotate(-3deg); } /* Step L1 + Bob Up + Pop */
-            86% { transform: translate(4vw, 0px) scale(1) rotate(0deg); }      /* Land L1 */
+            /* 1 step left, towards center */
+            80% { transform: translate(10vw, -10px) scale(1.02) rotate(-3deg); } /* Step L1 */
+            86% { transform: translate(12vw, 0px) scale(1) rotate(0deg); }      /* Land L1 */
 
-            /* Pause/Groove */
-            86%, 99% { transform: translate(4vw, 0px) scale(1) rotate(0deg); } /* Hold */
+            /* Pause/Groove near right-center */
+            86%, 99% { transform: translate(12vw, 2px) scale(0.98) rotate(-1deg); } /* Hold with slight dip/sway */
             100% { transform: translate(0vw, 0px) scale(1) rotate(0deg); }     /* End Center, loop */
         }
 


### PR DESCRIPTION
Adjusts the `@keyframes detailedCripWalk` for the Blapu dancer in `new-ui.html` to provide a wider side-to-side movement.

- Increased the peak `translateX` values to approximately +/- 28vw (from +/- 10vw), allowing the dancer to be more visible in the side margins on wider screens.
- The animation retains its rhythmic hip-hop style, including bobbing, popping, and phases where the dancer returns to or grooves near the center.

This addresses feedback that the dancer was too hidden behind the central content panel on desktop views.