### PR TITLE
fix: Adjust Blapu dancer animation speed and eye visibility

### DIFF
--- a/new-ui.html
+++ b/new-ui.html
@@ -119,7 +119,7 @@
             width: 250px;
             height: 325px;
             z-index: -2;
-            animation: detailedCripWalk 15s infinite ease-in-out; /* Smoother timing */
+            animation: detailedCripWalk 30s infinite ease-in-out; /* Halved speed */
             filter: blur(7px); /* Slightly reduced blur */
         }
 
@@ -195,13 +195,13 @@
             overflow: hidden;
         }
          /* Eyelid relative to .eye */
-        .blapu-dancer .eye::before {
+        .blapu-dancer .eye::before { /* Droopy eyelid */
             content: '';
             position: absolute;
-            top: -55.5%; /* -25px / 45px eye height */
-            left: -9%;   /* -5px / 55px eye width */
-            width: 118%;  /* 65px / 55px eye width */
-            height: 111%; /* 50px / 45px eye height */
+            top: -45%; /* Adjusted: Eyelid starts a bit higher relative to its own new height */
+            left: -10%;
+            width: 120%;
+            height: 90%; /* Adjusted: Eyelid is not as tall, reveals more white */
             background: #1e50ff;
             border-bottom: 2px solid #000;
             border-radius: 50%;
@@ -209,11 +209,11 @@
         /* Pupil relative to .eye */
         .blapu-dancer .pupil {
             position: absolute;
-            bottom: 16.6%; /* 7.5px / 45px eye height */
+            bottom: 15%; /* Adjusted: Pupil slightly lower */
             left: 50%;
             transform: translateX(-50%);
-            width: 31.8%;  /* 17.5px / 55px eye width */
-            height: 44.4%; /* 20px / 45px eye height */
+            width: 30%;  /* Adjusted: Pupil slightly smaller width */
+            height: 35%; /* Adjusted: Pupil slightly smaller height */
             background: #000;
             border-radius: 50%;
         }
@@ -279,7 +279,7 @@
             border: 2px solid #000;
             z-index: 2;
             animation-name: blapuArmSwing;
-            animation-duration: 1.5s;
+            animation-duration: 3s; /* Halved speed */
             animation-iteration-count: infinite;
             animation-timing-function: ease-in-out;
             animation-direction: alternate;
@@ -326,7 +326,7 @@
             background: #bdc3c7;
             border: 2px solid #000;
             animation-name: blapuLegSwing;
-            animation-duration: 1s;
+            animation-duration: 2s; /* Halved speed */
             animation-iteration-count: infinite;
             animation-timing-function: ease-in-out;
             transform-origin: center top;


### PR DESCRIPTION
Implements two key refinements for the Blapu dancer in `new-ui.html`:

1.  **Halved Animation Speed:** Doubled the `animation-duration` for the main body (`detailedCripWalk` to 30s), arms (`blapuArmSwing` to 3s), and legs (`blapuLegSwing` to 2s). This makes the overall dance animation significantly slower and smoother.
2.  **Improved Eye Visibility:** Adjusted the CSS for the dancer's eyes (eyelid and pupil size/positioning) to ensure that a portion of the white sclera is clearly visible, correcting an issue where it was obscured. The droopy, cartoonish eye style is maintained.

These changes enhance the animation's quality and fix a visual detail in the character's appearance.