### PR TITLE
fix: Correct Blapu dancer eye CSS for sclera visibility

### DIFF
--- a/new-ui.html
+++ b/new-ui.html
@@ -198,13 +198,13 @@
         .blapu-dancer .eye::before { /* Droopy eyelid */
             content: '';
             position: absolute;
-            top: -45%; /* Adjusted: Eyelid starts a bit higher relative to its own new height */
-            left: -10%;
-            width: 120%;
-            height: 90%; /* Adjusted: Eyelid is not as tall, reveals more white */
+            top: -50%; /* Starts halfway up its own height, above the eye's top edge */
+            left: -10%; /* Slight overhang for better curve coverage */
+            width: 120%; /* Slightly wider than eye for curve */
+            height: 100%; /* Same height as the eye itself */
             background: #1e50ff;
             border-bottom: 2px solid #000;
-            border-radius: 50%;
+            border-radius: 50%; /* This will make the bottom edge curved */
         }
         /* Pupil relative to .eye */
         .blapu-dancer .pupil {


### PR DESCRIPTION
Adjusts the CSS for the Blapu dancer's eyes in `new-ui.html` to ensure the white sclera is properly visible, based on re-evaluating the reference design's proportions.

- The eyelid (`.eye::before`) styling, specifically its `top` and `height` properties relative to the eye, has been modified to ensure it covers approximately the top 50% of the eye.
- This correction leaves the lower half of the eye's white sclera visible, with the pupil correctly positioned within this area.
- The fix addresses an issue where the eyelid might have been covering too much of the eye, obscuring the white.