### PR TITLE
Feat: Shift dancer animation path 30% to the left

### DIFF
--- a/new-ui.html
+++ b/new-ui.html
@@ -19,12 +19,13 @@
     :root {
       /* Variables for controlling Blapu character's crip walk animation extents. */
       /* These are adjusted in media queries for responsiveness. */
-      /* Magnitudes initially set to +/-40vw, then reduced to +/-35vw (and further in MQs) */
-      /* to prevent character from going too far off-screen and ensure more balanced visual centering. */
-      --crip-walk-start: -35vw; /* Default starting/ending X position (relative to center) */
-      --crip-walk-mid-1: 0vw;   /* Mid-point of travel (center screen) */
-      --crip-walk-end: 35vw;    /* Default main travel X position (relative to center) */
-      --crip-walk-mid-2: 0vw;   /* Mid-point of travel (center screen) */
+      /* Animation path is now centered around -30vw (30% to the left of screen center) */
+      /* to make the character appear mostly on the left side. */
+      /* Base travel radius is 35vw (total width 70vw). */
+      --crip-walk-start: -65vw; /* -30vw (center) - 35vw (radius) */
+      --crip-walk-mid-1: -30vw;  /* Animation path's new center point */
+      --crip-walk-end: 5vw;     /* -30vw (center) + 35vw (radius) */
+      --crip-walk-mid-2: -30vw;  /* Animation path's new center point */
     }
 
     /* General Page Setup */
@@ -513,12 +514,12 @@
         height: 416px;
         filter: blur(7px);
       }
-      /* Reduce crip walk animation range for medium screens (previously +/-30vw, now +/-25vw) */
+      /* Adjust crip walk for medium screens: center -30vw, radius 25vw. */
       :root {
-        --crip-walk-start: -25vw;
-        --crip-walk-mid-1: 0vw;
-        --crip-walk-end: 25vw;
-        --crip-walk-mid-2: 0vw;
+        --crip-walk-start: -55vw; /* -30vw - 25vw */
+        --crip-walk-mid-1: -30vw;
+        --crip-walk-end: -5vw;    /* -30vw + 25vw */
+        --crip-walk-mid-2: -30vw;
       }
     }
 
@@ -583,12 +584,12 @@
         height: 260px;
         filter: blur(8px);
       }
-      /* Further reduce crip walk animation range for small screens (previously +/-25vw, now +/-20vw) */
+      /* Adjust crip walk for small screens: center -30vw, radius 20vw. */
       :root {
-        --crip-walk-start: -20vw;
-        --crip-walk-mid-1: 0vw;
-        --crip-walk-end: 20vw;
-        --crip-walk-mid-2: 0vw;
+        --crip-walk-start: -50vw; /* -30vw - 20vw */
+        --crip-walk-mid-1: -30vw;
+        --crip-walk-end: -10vw;   /* -30vw + 20vw */
+        --crip-walk-mid-2: -30vw;
       }
     }
 
@@ -601,12 +602,12 @@
         filter: blur(9px);
       }
       /* Most restricted crip walk animation range for very small screens */
-      /* This helps prevent the character from causing layout overflow issues. (previously +/-20vw, now +/-15vw) */
+      /* Adjust crip walk for very small screens: center -30vw, radius 15vw. */
       :root {
-        --crip-walk-start: -15vw;
-        --crip-walk-mid-1: 0vw;
-        --crip-walk-end: 15vw;
-        --crip-walk-mid-2: 0vw;
+        --crip-walk-start: -45vw; /* -30vw - 15vw */
+        --crip-walk-mid-1: -30vw;
+        --crip-walk-end: -15vw;   /* -30vw + 15vw */
+        --crip-walk-mid-2: -30vw;
       }
     }
   </style>


### PR DESCRIPTION
- Updated CSS variables for the `detailedCripWalk` animation to center its horizontal path around -30vw relative to the screen center.
- Recalculated `--crip-walk-start`, `--crip-walk-mid-1`, `--crip-walk-end`, and `--crip-walk-mid-2` values for all breakpoints (base, 700px, 520px, 380px) to reflect this new centered path while maintaining previously established travel radii.
- This change makes the dancer animate predominantly on the left side of the screen.
- Updated CSS comments to explain the new animation path logic and values.