### PR TITLE
Fix: Center dancer animation path at 0vw (true screen center)

### DIFF
--- a/new-ui.html
+++ b/new-ui.html
@@ -19,13 +19,12 @@
     :root {
       /* Variables for controlling Blapu character's crip walk animation extents. */
       /* These are adjusted in media queries for responsiveness. */
-      /* Animation path is now centered around +5vw (5% to the right of screen center) */
-      /* based on iterative user feedback to achieve desired visual centering. */
+      /* Animation path is now centered around 0vw (true screen center) based on iterative feedback. */
       /* Base travel radius is 35vw (total width 70vw). */
-      --crip-walk-start: -30vw; /* +5vw (new_center) - 35vw (radius) */
-      --crip-walk-mid-1: 5vw;    /* Animation path's new center point */
-      --crip-walk-end: 40vw;    /* +5vw (new_center) + 35vw (radius) */
-      --crip-walk-mid-2: 5vw;    /* Animation path's new center point */
+      --crip-walk-start: -35vw; /* 0vw (new_center) - 35vw (radius) */
+      --crip-walk-mid-1: 0vw;    /* Animation path's new center point (true center) */
+      --crip-walk-end: 35vw;     /* 0vw (new_center) + 35vw (radius) */
+      --crip-walk-mid-2: 0vw;    /* Animation path's new center point (true center) */
     }
 
     /* General Page Setup */
@@ -514,12 +513,12 @@
         height: 416px;
         filter: blur(7px);
       }
-      /* Adjust crip walk for medium screens: new center +5vw, radius 25vw. */
+      /* Adjust crip walk for medium screens: new center 0vw, radius 25vw. */
       :root {
-        --crip-walk-start: -20vw; /* +5vw (new_center) - 25vw (radius) */
-        --crip-walk-mid-1: 5vw;
-        --crip-walk-end: 30vw;    /* +5vw (new_center) + 25vw (radius) */
-        --crip-walk-mid-2: 5vw;
+        --crip-walk-start: -25vw; /* 0vw (new_center) - 25vw (radius) */
+        --crip-walk-mid-1: 0vw;
+        --crip-walk-end: 25vw;    /* 0vw (new_center) + 25vw (radius) */
+        --crip-walk-mid-2: 0vw;
       }
     }
 
@@ -584,12 +583,12 @@
         height: 260px;
         filter: blur(8px);
       }
-      /* Adjust crip walk for small screens: new center +5vw, radius 20vw. */
+      /* Adjust crip walk for small screens: new center 0vw, radius 20vw. */
       :root {
-        --crip-walk-start: -15vw; /* +5vw (new_center) - 20vw (radius) */
-        --crip-walk-mid-1: 5vw;
-        --crip-walk-end: 25vw;    /* +5vw (new_center) + 20vw (radius) */
-        --crip-walk-mid-2: 5vw;
+        --crip-walk-start: -20vw; /* 0vw (new_center) - 20vw (radius) */
+        --crip-walk-mid-1: 0vw;
+        --crip-walk-end: 20vw;    /* 0vw (new_center) + 20vw (radius) */
+        --crip-walk-mid-2: 0vw;
       }
     }
 
@@ -602,12 +601,12 @@
         filter: blur(9px);
       }
       /* Most restricted crip walk animation range for very small screens */
-      /* Adjust crip walk for very small screens: new center +5vw, radius 15vw. */
+      /* Adjust crip walk for very small screens: new center 0vw, radius 15vw. */
       :root {
-        --crip-walk-start: -10vw; /* +5vw (new_center) - 15vw (radius) */
-        --crip-walk-mid-1: 5vw;
-        --crip-walk-end: 20vw;    /* +5vw (new_center) + 15vw (radius) */
-        --crip-walk-mid-2: 5vw;
+        --crip-walk-start: -15vw; /* 0vw (new_center) - 15vw (radius) */
+        --crip-walk-mid-1: 0vw;
+        --crip-walk-end: 15vw;    /* 0vw (new_center) + 15vw (radius) */
+        --crip-walk-mid-2: 0vw;
       }
     }
   </style>


### PR DESCRIPTION
- Adjusted CSS variables (`--crip-walk-start`, `--crip-walk-mid-1`, `--crip-walk-end`, `--crip-walk-mid-2`) for the `detailedCripWalk` animation.
- The animation path is now mathematically centered around 0vw (true screen center) across all breakpoints, with equal travel distance to the left and right (e.g., +/-35vw at base resolution).
- This adjustment is based on iterative user feedback to achieve the desired visual centering of the animation.
- Updated CSS comments to reflect the new 0vw centered path logic and values.