### PR TITLE
Fix: Center dancer animation at -9vw and update UI link text

### DIFF
--- a/new-ui.html
+++ b/new-ui.html
@@ -19,13 +19,13 @@
     :root {
       /* Variables for controlling Blapu character's crip walk animation extents. */
       /* These are adjusted in media queries for responsiveness. */
-      /* Animation path is now centered around -8vw (8% to the left of screen center) */
+      /* Animation path is now centered around -9vw (9% to the left of screen center) */
       /* based on iterative user feedback to achieve desired visual centering. */
       /* Base travel radius is 35vw (total width 70vw). */
-      --crip-walk-start: -43vw; /* -8vw (new_center) - 35vw (radius) */
-      --crip-walk-mid-1: -8vw;   /* Animation path's new center point */
-      --crip-walk-end: 27vw;    /* -8vw (new_center) + 35vw (radius) */
-      --crip-walk-mid-2: -8vw;   /* Animation path's new center point */
+      --crip-walk-start: -44vw; /* -9vw (new_center) - 35vw (radius) */
+      --crip-walk-mid-1: -9vw;   /* Animation path's new center point */
+      --crip-walk-end: 26vw;    /* -9vw (new_center) + 35vw (radius) */
+      --crip-walk-mid-2: -9vw;   /* Animation path's new center point */
     }
 
     /* General Page Setup */
@@ -514,12 +514,12 @@
         height: 416px;
         filter: blur(7px);
       }
-      /* Adjust crip walk for medium screens: new center -8vw, radius 25vw. */
+      /* Adjust crip walk for medium screens: new center -9vw, radius 25vw. */
       :root {
-        --crip-walk-start: -33vw; /* -8vw (new_center) - 25vw (radius) */
-        --crip-walk-mid-1: -8vw;
-        --crip-walk-end: 17vw;    /* -8vw (new_center) + 25vw (radius) */
-        --crip-walk-mid-2: -8vw;
+        --crip-walk-start: -34vw; /* -9vw (new_center) - 25vw (radius) */
+        --crip-walk-mid-1: -9vw;
+        --crip-walk-end: 16vw;    /* -9vw (new_center) + 25vw (radius) */
+        --crip-walk-mid-2: -9vw;
       }
     }
 
@@ -584,12 +584,12 @@
         height: 260px;
         filter: blur(8px);
       }
-      /* Adjust crip walk for small screens: new center -8vw, radius 20vw. */
+      /* Adjust crip walk for small screens: new center -9vw, radius 20vw. */
       :root {
-        --crip-walk-start: -28vw; /* -8vw (new_center) - 20vw (radius) */
-        --crip-walk-mid-1: -8vw;
-        --crip-walk-end: 12vw;    /* -8vw (new_center) + 20vw (radius) */
-        --crip-walk-mid-2: -8vw;
+        --crip-walk-start: -29vw; /* -9vw (new_center) - 20vw (radius) */
+        --crip-walk-mid-1: -9vw;
+        --crip-walk-end: 11vw;    /* -9vw (new_center) + 20vw (radius) */
+        --crip-walk-mid-2: -9vw;
       }
     }
 
@@ -602,12 +602,12 @@
         filter: blur(9px);
       }
       /* Most restricted crip walk animation range for very small screens */
-      /* Adjust crip walk for very small screens: new center -8vw, radius 15vw. */
+      /* Adjust crip walk for very small screens: new center -9vw, radius 15vw. */
       :root {
-        --crip-walk-start: -23vw; /* -8vw (new_center) - 15vw (radius) */
-        --crip-walk-mid-1: -8vw;
-        --crip-walk-end: 7vw;     /* -8vw (new_center) + 15vw (radius) */
-        --crip-walk-mid-2: -8vw;
+        --crip-walk-start: -24vw; /* -9vw (new_center) - 15vw (radius) */
+        --crip-walk-mid-1: -9vw;
+        --crip-walk-end: 6vw;     /* -9vw (new_center) + 15vw (radius) */
+        --crip-walk-mid-2: -9vw;
       }
     }
   </style>
@@ -677,7 +677,7 @@
       </div>
     </div>
     <div class="footer-nav">
-      <a href="index.html" id="go-to-old-ui">Old UI</a>
+      <a href="index.html" id="go-to-old-ui">Chan UI</a>
       <span class="separator">&bull;</span>
       <a href="https://x.com/BlapuGANG" target="_blank" rel="noopener noreferrer">X (Twitter)</a>
       <span class="separator">&bull;</span>


### PR DESCRIPTION
- Adjusted CSS variables for the `detailedCripWalk` animation to mathematically center its path around -9vw (9% to the left of screen center) across all breakpoints. This is a further fine-tuning based on iterative user feedback.
- Updated the text of the link in the footer navigation from "Old UI" to "Chan UI" as requested.
- Updated CSS comments to reflect the new -9vw centered path logic and values.