### PR TITLE
Fix: Reduce excessive top spacing on new-ui page

### DIFF
--- a/styles/new-ui.css
+++ b/styles/new-ui.css
@@ -23,7 +23,7 @@
       width: 100%; /* Crucial for preventing horizontal overflow issues */
       font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
       margin: 0;
-      padding: 10px; /* Base padding for the page content area. Reduced from 10px 20px. Adjusted in media queries. */
+      padding: 0.5vw; /* Was 10px. Base padding for the page content area. Aiming for ~1.5vw total top space with panel margin. */
       color: #fff; /* Default text color */
       min-height: 100vh; /* Ensure body takes at least full viewport height */
       background: linear-gradient(135deg, #1a2a6c, #b21f1f, #fdbb2d); /* Background gradient */
@@ -359,7 +359,7 @@
     .glass-panel {
       width: 90%; /* Responsive width relative to parent */
       max-width: 800px; /* Maximum width to maintain readability on large screens */
-      margin: 2.7778vw auto 2.0833vw auto; /* Was 40px auto 30px auto. Adjusted in media queries. */
+      margin: 1vw auto 2.0833vw auto; /* Was 2.7778vw (40px) top. Aiming for ~1.5vw total top space with body padding. */
       padding: 1.0417vw; /* Was 15px. Inner spacing. Base padding reduced from 20px. Adjusted in media queries. */
       text-align: center; /* Center-aligns inline content */
       z-index: 10; /* Ensures panel is above background elements */


### PR DESCRIPTION
- Adjusted body padding to 0.5vw.
- Adjusted .glass-panel margin-top to 1vw.
- This results in a combined top spacing of approximately 1.5vw on wider screens, addressing the issue of excessive spacing.
- Existing media queries will still manage spacing on smaller screens.