### PR TITLE
Feat: Adjust swap widget heights on mobile views

### DIFF
--- a/index.html
+++ b/index.html
@@ -533,7 +533,7 @@
         <blockquote class="postMessage" id="m123456869">
             <a href="#p123456854" class="quotelink">&gt;&gt;123456854</a><br>
             You forgot the swap, Greg. Looks like Bunsan broke the widget with v4 beta, you will need this https://beta.vestige.fi/asset/401752010 to buy...
-            <div style="width: auto; height: 400px; position: relative;">
+            <div class="chan-swap-widget-container" style="width: auto; height: 400px; position: relative;">
               <!--
                   Vestige Swap Widget for USDC (ASA ID: 31566704) to BLAPU (ASA ID: 401752010)
                   Parameters:

--- a/styles/new-ui.css
+++ b/styles/new-ui.css
@@ -626,6 +626,17 @@
         /* Vertical padding (padding-top, padding-bottom) remains as per the default .widget style (15px) unless specified otherwise. */
       }
 
+      /* Reduce height of swap widget on small screens for better layout. New height: 340px (15% reduction from 400px) */
+      .widget-swap { /* Target the container for the swap widget */
+        height: 340px;       /* Explicitly set height for mobile, reducing from desktop's 400px min-height. */
+        min-height: 340px;   /* Ensure min-height also respects this new, shorter height on mobile. */
+      }
+      .widget-swap iframe { /* Target the iframe directly within .widget-swap */
+        height: 100%;        /* Make iframe fill the new height of its .widget-swap parent. */
+        min-height: auto;    /* Override the iframe's own min-height (was 380px) to allow it to shrink. */
+      }
+
+
       /* Adjust Blapu character size for small screens */
       /* Character is hidden via display:none at 700px breakpoint, so these are fallback/reference if that changes. */
       .character-container {

--- a/styles/yotsubluenew.715.css
+++ b/styles/yotsubluenew.715.css
@@ -1731,3 +1731,14 @@ table.flashListing .subject {
   margin: 0;
   flex-grow: 1;
 }
+
+/* Custom Blapu Styles for Chan View Mobile Swap Widget */
+@media (max-width: 520px) {
+  /* Reduce height of the Vestige swap widget container on mobile for Chan view. */
+  /* New height: 320px (20% reduction from 400px). */
+  /* !important is used to override the inline style 'height: 400px;' in index.html. */
+  .chan-swap-widget-container {
+    height: 320px !important;
+  }
+  /* The iframe inside .chan-swap-widget-container has height="100%", so it will adapt. */
+}


### PR DESCRIPTION
- Reduced Vestige swap widget height by 15% (to 340px) on New UI (new-ui.html) for mobile screens (<= 520px).
- Reduced Vestige swap widget height by 20% (to 320px) on Chan view (index.html) for mobile screens (<= 520px).
- Added class to Chan view widget container and updated associated CSS (yotsubluenew.715.css) to enable mobile-specific height override.
- Updated comments to reflect changes.