### PR TITLE
Refine: Set mobile max-height for swap widgets and verify button text

### DIFF
--- a/styles/new-ui.css
+++ b/styles/new-ui.css
@@ -630,10 +630,12 @@
       .widget-swap { /* Target the container for the swap widget */
         height: 340px;       /* Explicitly set height for mobile, reducing from desktop's 400px min-height. */
         min-height: 340px;   /* Ensure min-height also respects this new, shorter height on mobile. */
+        max-height: 380px;   /* Max height constraint for mobile view, preventing widget from becoming too tall if content overflows. */
       }
       .widget-swap iframe { /* Target the iframe directly within .widget-swap */
         height: 100%;        /* Make iframe fill the new height of its .widget-swap parent. */
         min-height: auto;    /* Override the iframe's own min-height (was 380px) to allow it to shrink. */
+        max-height: 100%;    /* Ensure iframe respects parent's max-height, effectively capping it at 380px as well. */
       }
 
 

--- a/styles/yotsubluenew.715.css
+++ b/styles/yotsubluenew.715.css
@@ -1738,7 +1738,8 @@ table.flashListing .subject {
   /* New height: 320px (20% reduction from 400px). */
   /* !important is used to override the inline style 'height: 400px;' in index.html. */
   .chan-swap-widget-container {
-    height: 320px !important;
+    height: 320px !important; /* Sets the primary height for the container on mobile. */
+    max-height: 380px !important; /* Caps the container height at 380px on mobile, preventing excessive tallness. */
   }
-  /* The iframe inside .chan-swap-widget-container has height="100%", so it will adapt. */
+  /* The iframe inside .chan-swap-widget-container has height="100%", so it will adapt to both height and max-height of parent. */
 }


### PR DESCRIPTION
- Applied a `max-height: 380px` to Vestige swap widgets on mobile views (<= 520px) for both New UI and Chan View. This acts as a ceiling to the previously set shorter target heights.
- Verified button text "We want > TOP 35 LP by TVL on PowApp" in new-ui.html already meets spacing requirements; no changes made to text.
- Updated CSS comments to reflect max-height additions.