### PR TITLE
Feat: Reintegrate Blapu character into mobile UI

### DIFF
--- a/styles/new-ui.css
+++ b/styles/new-ui.css
@@ -534,10 +534,10 @@
       /* Adjust Blapu character size and animation for medium screens */
       /* On mobile devices (screen width <= 700px), the character is hidden to improve performance and save space. */
       .character-container {
-        display: none; /* HIDE Blapu mascot on screens 700px wide or less for mobile optimization. */
-        width: 160px; /* Halved from 320px - Kept for reference, but display:none overrides visibility */
-        height: 208px; /* Halved from 416px - Kept for reference */
-        filter: blur(7px); /* Kept for reference */
+        /* display: none; */ /* HIDE Blapu mascot on screens 700px wide or less for mobile optimization. - Commented out to re-enable */
+        width: 160px; /* Halved from 320px - Should now apply */
+        height: 208px; /* Halved from 416px - Should now apply */
+        filter: blur(7px); /* Should now apply */
       }
       /* Adjust crip walk for medium screens: current center -9vw, radius 25vw. */
       /* These vw values are relative to viewport and might not need direct scaling, */


### PR DESCRIPTION
The Blapu background character, previously hidden on mobile viewports (<= 700px width) for performance and space optimization, has been re-enabled.

This change comments out the `display: none;` rule in `styles/new-ui.css` targeting `.character-container` within the `@media (max-width: 700px)` query. The existing CSS rules for scaling the character's size, blur, and animation paths at various mobile breakpoints (700px, 520px, 380px) are now expected to take effect.

Further testing by the user will be needed to confirm acceptable visual layout and performance on mobile devices. If issues arise, adjustments to the CSS or consideration of an alternative implementation (e.g., simplified sprites) may be necessary.