### PR TITLE
Feat: Implement 'crazier' animation path for Blapu on mobile

### DIFF
--- a/styles/new-ui.css
+++ b/styles/new-ui.css
@@ -71,9 +71,9 @@
     /* translateY values adjusted for symmetrical vertical movement to balance perceived time on left/right. */
     @keyframes detailedCripWalk {
       0%   { transform: translateX(var(--crip-walk-start)) translateY(0px) rotate(-5deg); } /* Start left */
-      25%  { transform: translateX(var(--crip-walk-mid-1)) translateY(-15px) rotate(0deg); } /* Mid-transition point, dips down */
+      25%  { transform: translateX(var(--crip-walk-mid-1)) translateY(-45px) rotate(0deg); } /* Mid-transition point, dips down MORE */
       50%  { transform: translateX(var(--crip-walk-end)) translateY(0px) rotate(5deg); }   /* Furthest right, returns to base Y */
-      75%  { transform: translateX(var(--crip-walk-mid-2)) translateY(-15px) rotate(0deg); } /* Mid-transition point, dips down (symmetrical with 25% mark) */
+      75%  { transform: translateX(var(--crip-walk-mid-2)) translateY(-45px) rotate(0deg); } /* Mid-transition point, dips down MORE (symmetrical with 25% mark) */
       100% { transform: translateX(var(--crip-walk-start)) translateY(0px) rotate(-5deg); } /* Return to start */
     }
     /* Keyframes for arm and leg swing animations (decorative) */
@@ -668,10 +668,11 @@
       /* These vw values are relative to viewport and might not need direct scaling, */
       /* but are kept here for context. User requested size change, not animation path change. */
       :root {
-        --crip-walk-start: -34vw; /* -9vw (current_center) - 25vw (radius) */
-        --crip-walk-mid-1: -9vw;
-        --crip-walk-end: 16vw;    /* -9vw (current_center) + 25vw (radius) */
-        --crip-walk-mid-2: -9vw;
+        /* CRAZIER PATH for 700px */
+        --crip-walk-start: -42vw;
+        --crip-walk-mid-1: -5vw;
+        --crip-walk-end: 24vw;
+        --crip-walk-mid-2: -15vw;
       }
     }
 
@@ -874,10 +875,11 @@
       /* Adjust crip walk for small screens: current center -9vw, radius 20vw. */
       /* VW units are relative, not directly scaling. */
       :root {
-        --crip-walk-start: -29vw; /* -9vw (current_center) - 20vw (radius) */
-        --crip-walk-mid-1: -9vw;
-        --crip-walk-end: 11vw;    /* -9vw (current_center) + 20vw (radius) */
-        --crip-walk-mid-2: -9vw;
+        /* CRAZIER PATH for 520px */
+        --crip-walk-start: -35vw;
+        --crip-walk-mid-1: -2vw;
+        --crip-walk-end: 17vw;
+        --crip-walk-mid-2: -12vw;
       }
     }
 
@@ -1019,9 +1021,10 @@
       /* Adjust crip walk for very small screens: current center -9vw, radius 15vw. */
       /* VW units are relative, not directly scaling. */
       :root {
-        --crip-walk-start: -24vw; /* -9vw (current_center) - 15vw (radius) */
-        --crip-walk-mid-1: -9vw;
-        --crip-walk-end: 6vw;     /* -9vw (current_center) + 15vw (radius) */
-        --crip-walk-mid-2: -9vw;
+        /* CRAZIER PATH for 380px */
+        --crip-walk-start: -29vw;
+        --crip-walk-mid-1: 0vw;
+        --crip-walk-end: 11vw;
+        --crip-walk-mid-2: -10vw;
       }
     }


### PR DESCRIPTION
This commit updates the Blapu character's animation path for mobile viewports to be more dynamic, featuring increased horizontal and vertical movement, while maintaining the same overall animation duration (25s).

Changes include:
- Modified the `translateY` values in the `detailedCripWalk` keyframes from `-15px` to `-45px` at the 25% and 75% animation marks, resulting in a more significant vertical movement.
- Adjusted the CSS custom properties (`--crip-walk-start`, `--crip-walk-mid-1`, `--crip-walk-end`, `--crip-walk-mid-2`) within the media queries for `max-width: 700px`, `520px`, and `380px`.
  - The horizontal travel range (vw units) has been increased by approximately 25-30% for each breakpoint.
  - The mid-path points have been varied to create a less linear and more unpredictable trajectory.