### PR TITLE
Feat: Enhance mobile UI with reduced Blapu blur and aurora glass panel

### DIFF
--- a/styles/new-ui.css
+++ b/styles/new-ui.css
@@ -551,7 +551,7 @@
         /* display: none; */ /* Commented out to re-enable */
         width: 160px;   /* Base: 250px. Scale: 0.64 */
         height: 208px;  /* Base: 325px. Scale: 0.64 */
-        filter: blur(7px);
+        filter: blur(3px); /* Reduced blur */
       }
       /* SCALED CHARACTER PARTS for max-width: 700px (Factor: 0.64) */
       .character-container .head {
@@ -689,6 +689,36 @@
         --crip-walk-end-extreme: 70vw;
         --crip-walk-mid-2-extreme: 15vw;
       }
+
+      /* Aurora Glass Effect for Mobile */
+      .glass-panel {
+        overflow: hidden; /* To contain the ::after pseudo-element's blur */
+      }
+
+      .glass-panel::after {
+        content: "";
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        z-index: -2; /* Behind existing ::before (inner shadow) and content */
+        background-image:
+          radial-gradient(circle at 20% 30%, rgba(74, 144, 226, 0.2) 0%, transparent 35%),
+          radial-gradient(circle at 80% 70%, rgba(182, 31, 177, 0.15) 0%, transparent 40%),
+          radial-gradient(circle at 50% 50%, rgba(253, 187, 45, 0.15) 0%, transparent 30%);
+        background-size: 250% 250%;
+        animation: aurora-flow 20s ease-in-out infinite;
+        filter: blur(25px);
+        /* Ensure this pseudo-element does not interfere with pointer events on the panel itself */
+        pointer-events: none;
+      }
+
+      @keyframes aurora-flow {
+        0% { background-position: 0% 50%; }
+        50% { background-position: 100% 50%; }
+        100% { background-position: 0% 50%; }
+      }
     }
 
     /* For small tablets and large mobile phones (max-width: 520px) */
@@ -759,7 +789,7 @@
       .character-container {
         width: 100px; /* Base: 250px. Scale: 0.4 */
         height: 130px; /* Base: 325px. Scale: 0.4 */
-        filter: blur(8px);
+        filter: blur(4px); /* Reduced blur */
       }
       /* SCALED CHARACTER PARTS for max-width: 520px (Factor: 0.4) */
       .character-container .head {
@@ -904,7 +934,7 @@
       .character-container {
         width: 75px;    /* Base: 250px. Scale: 0.3 */
         height: 97.5px; /* Base: 325px. Scale: 0.3 */
-        filter: blur(9px);
+        filter: blur(4px); /* Reduced blur */
       }
       /* SCALED CHARACTER PARTS for max-width: 380px (Factor: 0.3) */
       .character-container .head {


### PR DESCRIPTION
This commit introduces two visual enhancements for the mobile user interface (screen widths <= 700px):

1.  Reduced Blur on Blapu Character:
    - The `filter: blur()` values for the `.character-container` have been decreased in mobile media queries (to 3px or 4px) to make Blapu appear sharper and more defined on smaller screens.

2.  Aurora Glass Effect for Panel:
    - The `.glass-panel` now features a subtle, animated 'aurora' effect on mobile.
    - This is implemented using an `::after` pseudo-element with multiple, soft radial gradients that slowly shift position.
    - The effect includes a `filter: blur(25px)` on the pseudo-element for a diffuse look and is contained within the panel using `overflow: hidden`.
    - The aurora is layered with `z-index: -2` to sit behind the panel's content and its existing inner shadow pseudo-element.

These changes aim to improve visual clarity for the Blapu character and add an elegant, dynamic background to the glass panel on mobile devices.