### PR TITLE
Feat: Implement dark mode for New UI

### DIFF
--- a/scripts/new-ui.js
+++ b/scripts/new-ui.js
@@ -43,3 +43,40 @@ document.addEventListener('DOMContentLoaded', function() {
     quotes[randomIndex].style.display = 'block'; // Show the randomly selected quote by setting its display style to 'block'
   }
 });
+
+// Dark Mode Toggle Functionality
+document.addEventListener('DOMContentLoaded', function() {
+  const themeToggleButton = document.querySelector('.blapu-logo-link'); // Blapu logo is the toggle
+  const bodyElement = document.body;
+
+  // Function to apply theme based on preference
+  function applyTheme(theme) {
+    if (theme === 'dark') {
+      bodyElement.classList.add('dark-mode');
+    } else {
+      bodyElement.classList.remove('dark-mode');
+    }
+  }
+
+  // Check for saved theme preference on load
+  const savedTheme = localStorage.getItem('theme');
+  if (savedTheme) {
+    applyTheme(savedTheme);
+  } // Default is light mode (no class)
+
+  // Event listener for the toggle button
+  if (themeToggleButton) {
+    themeToggleButton.addEventListener('click', function(event) {
+      event.preventDefault(); // Prevent navigation if the logo is also a link
+
+      bodyElement.classList.toggle('dark-mode');
+
+      // Save the new preference
+      if (bodyElement.classList.contains('dark-mode')) {
+        localStorage.setItem('theme', 'dark');
+      } else {
+        localStorage.setItem('theme', 'light');
+      }
+    });
+  }
+});

--- a/styles/new-ui.css
+++ b/styles/new-ui.css
@@ -57,6 +57,37 @@
         border-radius: 60% 40% 70% 30% / 50% 50% 40% 60%;
       }
     }
+
+/* Dark Mode Styles */
+body.dark-mode {
+  background: linear-gradient(135deg, #000000 0%, #300030 70%, #4B0082 100%);
+  /* Ensure text color is appropriate if not handled by more specific selectors,
+     though most text is in .glass-panel which should maintain its light text.
+     Defaulting to white for any potential stray text on the body. */
+  color: #fff;
+}
+
+body.dark-mode .glass-panel::after {
+  /* Adjust aurora colors for better visibility/harmony in dark mode */
+  background-image:
+    radial-gradient(circle at 20% 30%, rgba(74, 144, 226, 0.3) 0%, transparent 35%), /* Increased opacity */
+    radial-gradient(circle at 80% 70%, rgba(182, 31, 177, 0.25) 0%, transparent 40%), /* Increased opacity */
+    radial-gradient(circle at 50% 50%, rgba(253, 187, 45, 0.25) 0%, transparent 30%); /* Increased opacity */
+}
+
+body.dark-mode .blapu-blob {
+  opacity: 0.6; /* Adjusted base opacity for dark mode blobs */
+}
+body.dark-mode .blob-1 {
+  background: radial-gradient(circle at center, rgba(220, 100, 255, 0.6), rgba(150, 50, 180, 0.8));
+}
+body.dark-mode .blob-2 {
+  background: radial-gradient(circle at center, rgba(80, 120, 255, 0.6), rgba(40, 70, 190, 0.8));
+}
+body.dark-mode .blob-3 {
+  background: radial-gradient(circle at center, rgba(160, 120, 255, 0.55), rgba(100, 80, 190, 0.75));
+}
+
     /* Individual blob styling */
     .blapu-blob {
       position: absolute; /* Positioned relative to the body or nearest positioned ancestor */


### PR DESCRIPTION
This commit introduces a dark mode feature for the new UI, toggleable by clicking the Blapu logo.

Key changes:

1.  JavaScript (`scripts/new-ui.js`):
    - Added event listener to the Blapu logo (`.blapu-logo-link`) to toggle a `dark-mode` class on the `<body>`.
    - Implemented theme persistence using `localStorage` to remember your choice (dark/light) across sessions.
    - The theme is applied on page load based on the saved preference.
    - Default link navigation on the logo is prevented.

2.  CSS (`styles/new-ui.css`):
    - Added `body.dark-mode` styles for the new theme.
    - Page background in dark mode is a linear gradient from black to deep rich purple (`#000000` -> `#300030` -> `#4B0082`).
    - Blob colors and base opacity are adjusted for better visibility and harmony in dark mode (more vibrant purples/blues).
    - The aurora effect within the `.glass-panel::after` has its gradient colors' opacities slightly increased for better visibility in dark mode.
    - No direct color changes were made to the Blapu character or the main glass panel's own background/border, as they are expected to adapt well. Text within the panel remains light.

This feature provides you with an alternative visual theme, designed with a pure black to deep purple aesthetic, while ensuring the animated blobs and dancer remain integral parts of the experience.