### PR TITLE
Refactor: Revert desktop Blapu path and use cookies for theme store

### DIFF
--- a/scripts/new-ui.js
+++ b/scripts/new-ui.js
@@ -42,7 +42,31 @@ document.addEventListener('DOMContentLoaded', function() {
     const randomIndex = Math.floor(Math.random() * quotes.length); // Get a random index
     quotes[randomIndex].style.display = 'block'; // Show the randomly selected quote by setting its display style to 'block'
   }
+    quotes[randomIndex].style.display = 'block'; // Show the randomly selected quote by setting its display style to 'block'
+  }
 });
+
+// Cookie helper functions
+function setCookie(name, value, days) {
+  let expires = "";
+  if (days) {
+    const date = new Date();
+    date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000));
+    expires = "; expires=" + date.toUTCString();
+  }
+  document.cookie = name + "=" + (value || "") + expires + "; path=/; SameSite=Lax";
+}
+
+function getCookie(name) {
+  const nameEQ = name + "=";
+  const ca = document.cookie.split(';');
+  for (let i = 0; i < ca.length; i++) {
+    let c = ca[i];
+    while (c.charAt(0) === ' ') c = c.substring(1, c.length);
+    if (c.indexOf(nameEQ) === 0) return c.substring(nameEQ.length, c.length);
+  }
+  return null;
+}
 
 // Dark Mode Toggle Functionality
 document.addEventListener('DOMContentLoaded', function() {
@@ -58,8 +82,8 @@ document.addEventListener('DOMContentLoaded', function() {
     }
   }
 
-  // Check for saved theme preference on load
-  const savedTheme = localStorage.getItem('theme');
+  // Check for saved theme preference on load using cookies
+  const savedTheme = getCookie('theme');
   if (savedTheme) {
     applyTheme(savedTheme);
   } // Default is light mode (no class)
@@ -71,11 +95,11 @@ document.addEventListener('DOMContentLoaded', function() {
 
       bodyElement.classList.toggle('dark-mode');
 
-      // Save the new preference
+      // Save the new preference using cookies
       if (bodyElement.classList.contains('dark-mode')) {
-        localStorage.setItem('theme', 'dark');
+        setCookie('theme', 'dark', 30); // Cookie expires in 30 days
       } else {
-        localStorage.setItem('theme', 'light');
+        setCookie('theme', 'light', 30); // Cookie expires in 30 days
       }
     });
   }

--- a/styles/new-ui.css
+++ b/styles/new-ui.css
@@ -10,11 +10,11 @@
       /* Variables for controlling Blapu character's crip walk animation extents. */
       /* These are adjusted in media queries for responsiveness. */
       /* Using 'extreme' names to match the updated detailedCripWalk keyframes. */
-      /* Desktop path values: */
+      /* Desktop path values reverted to simpler, centered path as per user request: */
       --crip-walk-start-extreme: -45vw; /* Desktop's 'far left' */
-      --crip-walk-mid-1-extreme: -20vw; /* Desktop's re-entry path from left */
+      --crip-walk-mid-1-extreme: -10vw; /* Desktop's re-entry path from left, symmetrical */
       --crip-walk-end-extreme: 25vw;    /* Desktop's 'far right' */
-      --crip-walk-mid-2-extreme: 5vw;  /* Desktop's re-entry path from right */
+      --crip-walk-mid-2-extreme: -10vw; /* Desktop's re-entry path from right, symmetrical */
 
       /* Original desktop values (commented out as they are replaced by the above for the new keyframes)
       --crip-walk-start: -45vw;


### PR DESCRIPTION
This commit includes two main adjustments:

1.  Reverted Blapu's desktop animation path:
    - Global `:root` CSS variables (`--crip-walk-*-extreme`) updated to ensure the desktop animation path for Blapu is simpler and centered (approx. -45vw to 25vw, with -10vw midpoints for re-entry).
    - This utilizes the existing `detailedCripWalk` keyframes (with pauses/hops) but applies them to the original, less extreme desktop travel range.
    - Mobile animation paths remain unchanged (more extreme).

2.  Changed theme persistence to cookies:
    - Modified `scripts/new-ui.js` to use cookies instead of `localStorage` for storing and retrieving your dark/light mode theme preference.
    - Implemented `setCookie` and `getCookie` helper functions.
    - The 'theme' cookie is set with a 30-day expiration.