### PR TITLE
Fix: Resolve UI/UX issues in new-ui page

### DIFF
--- a/scripts/new-ui.js
+++ b/scripts/new-ui.js
@@ -1,52 +1,4 @@
-// Script to handle the functionality of the "Go to Old UI" button.
-// It sets a cookie to remember the user's choice and redirects to index.html.
-
-const goToOldUiButton = document.getElementById('go-to-old-ui'); // Get the button element
-
-// Function to set a cookie
-// name: Name of the cookie
-// value: Value of the cookie
-// days: Number of days until the cookie expires
-function setCookie(name, value, days) {
-  let expires = ""; // Initialize expires string
-  if (days) { // If 'days' is provided, calculate expiration date
-    const date = new Date();
-    date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000)); // Convert days to milliseconds
-    expires = "; expires=" + date.toUTCString(); // Format expires string for cookie
-  }
-  // Set the cookie with the provided name, value, expiration, and root path
-  document.cookie = name + "=" + (value || "") + expires + "; path=/";
-}
-
-// Check if the "Go to Old UI" button exists on the page
-if (goToOldUiButton) {
-  // Add a click event listener to the button
-  goToOldUiButton.addEventListener('click', (event) => {
-    event.preventDefault(); // Prevent the default link navigation behavior
-    // Set a cookie named 'siteChoice' with value 'old', expiring in 30 days
-    setCookie('siteChoice', 'old', 30);
-    // Redirect the user to the old UI (index.html)
-    window.location.href = 'index.html';
-  });
-}
-
-// JavaScript for displaying a random quote
-document.addEventListener('DOMContentLoaded', function() {
-  // Select all paragraphs with the class 'rotating-quote' that are children of .glass-panel
-  const quotes = document.querySelectorAll('.glass-panel > p.rotating-quote');
-
-  if (quotes.length > 0) {
-    // CSS already hides these by default (.rotating-quote { display: none; }),
-    // so no need to hide via JS. This prevents a Flash Of Unstyled Content (FOUC).
-
-    const randomIndex = Math.floor(Math.random() * quotes.length); // Get a random index
-    quotes[randomIndex].style.display = 'block'; // Show the randomly selected quote by setting its display style to 'block'
-  }
-    quotes[randomIndex].style.display = 'block'; // Show the randomly selected quote by setting its display style to 'block'
-  }
-});
-
-// Cookie helper functions
+// Cookie helper functions (Consolidated)
 function setCookie(name, value, days) {
   let expires = "";
   if (days) {
@@ -55,6 +7,7 @@ function setCookie(name, value, days) {
     expires = "; expires=" + date.toUTCString();
   }
   document.cookie = name + "=" + (value || "") + expires + "; path=/; SameSite=Lax";
+  console.log("Cookie set:", name, "=", value, "; expires=", expires); // Logging for theme cookie
 }
 
 function getCookie(name) {
@@ -68,10 +21,41 @@ function getCookie(name) {
   return null;
 }
 
-// Dark Mode Toggle Functionality
+// Script to handle the functionality of the "Go to Old UI" button.
+// It sets a cookie to remember the user's choice and redirects to index.html.
 document.addEventListener('DOMContentLoaded', function() {
+  const goToOldUiButton = document.getElementById('go-to-old-ui'); // Get the button element
+
+  // Check if the "Go to Old UI" button exists on the page
+  if (goToOldUiButton) {
+    // Add a click event listener to the button
+    goToOldUiButton.addEventListener('click', (event) => {
+      event.preventDefault(); // Prevent the default link navigation behavior
+      // Set a cookie named 'siteChoice' with value 'old', expiring in 30 days
+      setCookie('siteChoice', 'old', 30);
+      // Redirect the user to the old UI (index.html)
+      window.location.href = 'index.html';
+    });
+  }
+
+  // JavaScript for displaying a random quote
+  // Select all paragraphs with the class 'rotating-quote' that are children of .glass-panel
+  const quotes = document.querySelectorAll('.glass-panel > p.rotating-quote');
+
+  if (quotes.length > 0) {
+    // CSS already hides these by default (.rotating-quote { display: none; }),
+    // so no need to hide via JS. This prevents a Flash Of Unstyled Content (FOUC).
+
+    const randomIndex = Math.floor(Math.random() * quotes.length); // Get a random index
+    quotes[randomIndex].style.display = 'block'; // Show the randomly selected quote by setting its display style to 'block'
+  }
+  // Removed duplicated line: quotes[randomIndex].style.display = 'block';
+
+  // Dark Mode Toggle Functionality
   const themeToggleButton = document.querySelector('.blapu-logo-link'); // Blapu logo is the toggle
   const bodyElement = document.body;
+  console.log("Theme toggle button found:", themeToggleButton);
+
 
   // Function to apply theme based on preference
   function applyTheme(theme) {
@@ -91,9 +75,13 @@ document.addEventListener('DOMContentLoaded', function() {
   // Event listener for the toggle button
   if (themeToggleButton) {
     themeToggleButton.addEventListener('click', function(event) {
-      event.preventDefault(); // Prevent navigation if the logo is also a link
+      console.log("Blapu logo clicked. Event object:", event);
+      event.preventDefault();
+      console.log("event.defaultPrevented after preventDefault():", event.defaultPrevented);
 
+      console.log("Toggling dark mode. Current body classes:", bodyElement.classList.toString());
       bodyElement.classList.toggle('dark-mode');
+      console.log("Dark mode toggled. New body classes:", bodyElement.classList.toString());
 
       // Save the new preference using cookies
       if (bodyElement.classList.contains('dark-mode')) {
@@ -102,5 +90,7 @@ document.addEventListener('DOMContentLoaded', function() {
         setCookie('theme', 'light', 30); // Cookie expires in 30 days
       }
     });
+  } else {
+    console.error("Theme toggle button (.blapu-logo-link) not found!");
   }
 });

--- a/styles/new-ui.css
+++ b/styles/new-ui.css
@@ -657,7 +657,7 @@ body.dark-mode .blob-3 {
       width: 100%;
       box-sizing: border-box;
       position: relative;
-      min-height: 45vh; /* Changed from rem to vh */
+      /* min-height: 45vh; -- Removed to allow container to shrink-to-fit iframe content */
     }
     .widget::before {
       content: 'Loading...';
@@ -679,17 +679,25 @@ body.dark-mode .blob-3 {
     .widget.loading::before {
       display: block; /* Show when .loading class is present */
     }
-    .widget-swap { min-height: 50vh; /* Changed from rem to vh */ }
+    /* .widget-swap { min-height: 50vh; } -- Removed to allow container to shrink-to-fit iframe content */
     .widget iframe {
       width: 100%;
-      height: 100%;
+      /* height: 100%; -- Removed to allow iframe to use its content height or explicit height attribute */
+      display: block; /* Ensure block behavior for sizing */
       border: none;
       border-radius: 0.75rem;
       min-height: 20.625rem; /* 330px (keeps a rem based min as fallback) */
     }
     .widget-swap iframe {
-      height: 100%; /* Ensure it fills parent */
+      /* height: 100%; -- Removed to allow iframe to use its content height or explicit height attribute */
+      display: block; /* Ensure block behavior for sizing */
+      width: 100%; /* Ensure it takes full width of its container */
       min-height: 23.75rem; /* 380px (keeps a rem based min as fallback) */
+      /* border and border-radius will be inherited from .widget iframe if not specified,
+         but it's good to be explicit or ensure .widget-swap iframe doesn't negate them if needed.
+         Assuming they should also be borderless and have the radius: */
+      border: none;
+      border-radius: 0.75rem;
     }
 
     /* Footer Navigation within Glass Panel */
@@ -848,6 +856,11 @@ body.dark-mode .blob-3 {
         --crip-walk-mid-1-extreme: -10vw;
         --crip-walk-end-extreme: 50vw;
         --crip-walk-mid-2-extreme: 10vw;
+      }
+
+      .widget-container {
+        gap: 0.75rem; /* Reduced gap for mobile (12px) */
+        margin-top: 0.75rem; /* Optionally reduce top margin too */
       }
     }
 


### PR DESCRIPTION
This commit addresses several UI and UX problems on the new-ui.html page:

1.  **Theme Toggle:**
    *   Ensured the Blapu logo click correctly toggles between light and dark themes without navigating to the old UI.
    *   Added extensive logging to `scripts/new-ui.js` for easier debugging of the theme toggle functionality.
    *   Consolidated duplicated cookie helper functions and ensured all DOM-dependent JavaScript executes after DOMContentLoaded.
    *   Cleaned up a duplicated line in the random quote display logic.

2.  **Desktop Widget Sizing:**
    *   Modified `styles/new-ui.css` to improve how Vestige widgets size.
    *   Removed `vh`-based `min-height` from widget containers (`.widget`, `.widget-swap`).
    *   Removed `height: 100%` from iframes within widgets.
    *   Widgets now use `display: block`, `width: 100%`, and rely on their content's natural height or their own `min-height` in `rem` units. This allows containers to better fit the iframe content.

3.  **Mobile Layout:**
    *   Verified CSS for preventing horizontal scroll and ensuring content centering.
    *   Improved vertical efficiency in `styles/new-ui.css` by reducing the `gap` and `margin-top` for the `.widget-container` on smaller mobile screens.