### PR TITLE
Here's what I've done to enhance the mobile UI and address the Safari…

### DIFF
--- a/new-ui.html
+++ b/new-ui.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Blapu - New UI</title>
   <meta name="description" content="Blapu: New simplified UI with Vestige widgets.">
+  <meta name="theme-color" content="#FDBB2D">
   <link rel="icon" href="assets/images/blapu-logo.png" type="image/png">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="styles/new-ui.css">

--- a/styles/new-ui.css
+++ b/styles/new-ui.css
@@ -47,10 +47,20 @@ html {
   */
   width: 100%;
   /*
+    height: 100%;
+    Ensures the html element always tries to fill the full height of its parent (the window).
+  */
+  height: 100%;
+  /*
     min-height: 100vh;
-    Ensures the html element spans the full height of the viewport.
+    Ensures the html element spans at least the full height of the viewport.
   */
   min-height: 100vh;
+  /*
+    background: linear-gradient(135deg, #1a2a6c, #b21f1f, #fdbb2d);
+    Mirrors body background to cover overscroll areas.
+  */
+  background: linear-gradient(135deg, #1a2a6c, #b21f1f, #fdbb2d);
   /*
     margin: 0;
     Removes the default browser margin from the html element.
@@ -81,8 +91,13 @@ body {
   */
   width: 100%;
   /*
+    height: 100%;
+    Ensures the body tries to fill the full height of its parent (html).
+  */
+  height: 100%;
+  /*
     min-height: 100vh;
-    Ensures the body spans the full height of the viewport.
+    Ensures the body spans at least the full height of the viewport.
   */
   min-height: 100vh;
   /*
@@ -1039,15 +1054,15 @@ p {
       padding: ...;
       Reduces body padding on small screens to maximize content space.
     */
-    padding: 0.3125rem 0.1875rem;
+    padding: 0.3125rem 0.1875rem; /* Keep as is, already small */
   }
   .glass-panel {
     /*
-      Reduces padding and margins for a more compact layout on small screens.
+      Further reduces padding and margins for a more compact layout on small screens.
     */
-    padding: 0.375rem;
-    margin-top: 0.125rem;
-    margin-bottom: 0.25rem;
+    padding: 0.3rem; /* Slightly reduced from 0.375rem */
+    margin-top: 0.125rem; /* Keep as is */
+    margin-bottom: 0.2rem; /* Slightly reduced from 0.25rem */
     /*
       width: 98%;
       Ensures the panel uses almost the full screen width.
@@ -1068,23 +1083,23 @@ p {
     */
     align-items: center;
     /*
-      gap: 0.375rem;
+      gap: 0.25rem; /* Reduced from 0.375rem */
       Reduces the gap between stacked items.
     */
-    gap: 0.375rem;
+    gap: 0.25rem;
     /*
-      margin-bottom: 0.5rem;
+      margin-bottom: 0.375rem; /* Reduced from 0.5rem */
       Reduces the space below the header.
     */
-    margin-bottom: 0.5rem;
+    margin-bottom: 0.375rem;
   }
 
   .glass-panel p {
     /*
-      margin-bottom: 0.75rem;
+      margin-bottom: 0.5rem; /* Reduced from 0.75rem */
       Reduces the margin below paragraphs on mobile.
     */
-    margin-bottom: 0.75rem;
+    margin-bottom: 0.5rem;
   }
 
   /* Mobile Footer Navigation Adjustments */
@@ -1093,9 +1108,9 @@ p {
     flex-wrap: wrap;
     justify-content: center;
     align-items: center;
-    gap: 0.5rem;
-    margin-top: 1rem;
-    padding: 0.375rem 0.5rem;
+    gap: 0.4rem; /* Slightly reduced from 0.5rem */
+    margin-top: 0.75rem; /* Reduced from 1rem */
+    padding: 0.3rem 0.4rem; /* Slightly reduced from 0.375rem 0.5rem */
   }
   .footer-nav a {
     flex-grow: 0;
@@ -1138,19 +1153,19 @@ p {
       filter: blur(0.25rem);
       Further reduces character blur.
     */
-    filter: blur(0.25rem);
+    filter: blur(0.25rem); /* Keep as is */
   }
   .widget-container {
     /*
-      gap: 0.5rem;
+      gap: 0.375rem; /* Reduced from 0.5rem */
       Reduces the gap between widgets.
     */
-    gap: 0.5rem;
+    gap: 0.375rem;
     /*
-      margin-top: 0.5rem;
+      margin-top: 0.375rem; /* Reduced from 0.5rem */
       Reduces the top margin of the widget container.
     */
-    margin-top: 0.5rem;
+    margin-top: 0.375rem;
   }
   :root {
     /*
@@ -1194,5 +1209,27 @@ p {
     --crip-walk-mid-1-extreme: -15vw;
     --crip-walk-end-extreme: 70vw;
     --crip-walk-mid-2-extreme: 15vw;
+  }
+
+  /* Further compactness for very small screens */
+  .glass-panel {
+    padding: 0.2rem;
+    margin-bottom: 0.15rem;
+  }
+  .hero-header {
+    gap: 0.15rem;
+    margin-bottom: 0.2rem;
+  }
+  .glass-panel p {
+    margin-bottom: 0.3rem;
+  }
+  .widget-container {
+    gap: 0.2rem;
+    margin-top: 0.2rem;
+  }
+  .footer-nav {
+    margin-top: 0.4rem;
+    padding: 0.2rem 0.3rem;
+    gap: 0.3rem;
   }
 }


### PR DESCRIPTION
… top bar issue:

- I've added a suggestion for the browser UI color in Safari and other mobile browsers by including `<meta name="theme-color">` in `new-ui.html`. I used a Blapu-themed orange/yellow for this.
- I've updated the styles for `html` and `body` in `styles/new-ui.css` to make sure the background gradient extends vertically, which is particularly important for overscroll situations on mobile devices.
- To create a more compact and concise layout on small screens, I've reduced the vertical margins and padding for several elements within `styles/new-ui.css`. These changes apply under mobile media queries (`max-width: 32.5rem` and `max-width: 23.75rem`).