### PR TITLE
feat: Add view counter to new UI

### DIFF
--- a/new-ui.html
+++ b/new-ui.html
@@ -72,6 +72,28 @@
     <p class="rotating-quote">
       Buy, LP, Farm, Hodl and collect cans for more blaps. Simple as. /blap
     </p>
+    <div class="view-counter">
+      <div class="glass-bubble">
+        <span class="count" id="daily-views">0</span>
+        <span class="label">Today</span>
+      </div>
+      <div class="glass-bubble">
+        <span class="count" id="weekly-views">0</span>
+        <span class="label">This Week</span>
+      </div>
+      <div class="glass-bubble">
+        <span class="count" id="monthly-views">0</span>
+        <span class="label">This Month</span>
+      </div>
+      <div class="glass-bubble">
+        <span class="count" id="yearly-views">0</span>
+        <span class="label">This Year</span>
+      </div>
+      <div class="glass-bubble">
+        <span class="count" id="all-time-views">0</span>
+        <span class="label">All Time</span>
+      </div>
+    </div>
     <div class="widget-container">
       <div class="widget widget-chart">
         <!--
@@ -116,5 +138,6 @@
     </div>
   </div>
   <script src="scripts/new-ui.js" defer></script>
+  <script src="scripts/view-counter.js" defer></script>
 </body>
 </html>

--- a/scripts/view-counter.js
+++ b/scripts/view-counter.js
@@ -1,0 +1,102 @@
+// Helper functions to get and set cookies
+function setCookie(name, value, days) {
+  let expires = "";
+  if (days) {
+    const date = new Date();
+    date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000));
+    expires = "; expires=" + date.toUTCString();
+  }
+  document.cookie = name + "=" + (value || "") + expires + "; path=/; SameSite=Lax";
+}
+
+function getCookie(name) {
+  const nameEQ = name + "=";
+  const ca = document.cookie.split(';');
+  for (let i = 0; i < ca.length; i++) {
+    let c = ca[i];
+    while (c.charAt(0) === ' ') c = c.substring(1, c.length);
+    if (c.indexOf(nameEQ) === 0) return c.substring(nameEQ.length, c.length);
+  }
+  return null;
+}
+
+// Function to get the week number of the year
+function getWeekNumber(d) {
+  d = new Date(Date.UTC(d.getFullYear(), d.getMonth(), d.getDate()));
+  d.setUTCDate(d.getUTCDate() + 4 - (d.getUTCDay() || 7));
+  const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
+  return Math.ceil((((d - yearStart) / 86400000) + 1) / 7);
+}
+
+// Core view counting logic
+function trackView() {
+  const now = new Date();
+  const today = now.toISOString().split('T')[0];
+  const thisWeek = now.getFullYear() + '-' + getWeekNumber(now);
+  const thisMonth = now.getFullYear() + '-' + (now.getMonth() + 1);
+  const thisYear = now.getFullYear();
+
+  // Get last visit timestamp
+  const lastVisit = getCookie('lastVisit');
+  setCookie('lastVisit', now.toISOString(), 365); // Update last visit
+
+  // All-Time Views
+  let allTimeViews = parseInt(getCookie('allTimeViews') || '0', 10);
+  if (!lastVisit) { // Only count new visitors for all-time
+      allTimeViews++;
+  }
+  setCookie('allTimeViews', allTimeViews, 365 * 10); // 10-year cookie
+
+  // Daily Views
+  let dailyViewsData = JSON.parse(getCookie('dailyViews') || '{}');
+  if (dailyViewsData.date !== today) {
+    dailyViewsData = { date: today, count: 0 };
+  }
+  dailyViewsData.count++;
+  setCookie('dailyViews', JSON.stringify(dailyViewsData), 1);
+
+  // Weekly Views
+  let weeklyViewsData = JSON.parse(getCookie('weeklyViews') || '{}');
+  if (weeklyViewsData.week !== thisWeek) {
+    weeklyViewsData = { week: thisWeek, count: 0 };
+  }
+  weeklyViewsData.count++;
+  setCookie('weeklyViews', JSON.stringify(weeklyViewsData), 7);
+
+  // Monthly Views
+  let monthlyViewsData = JSON.parse(getCookie('monthlyViews') || '{}');
+  if (monthlyViewsData.month !== thisMonth) {
+    monthlyViewsData = { month: thisMonth, count: 0 };
+  }
+  monthlyViewsData.count++;
+  setCookie('monthlyViews', JSON.stringify(monthlyViewsData), 30);
+
+  // Yearly Views
+  let yearlyViewsData = JSON.parse(getCookie('yearlyViews') || '{}');
+  if (yearlyViewsData.year !== thisYear) {
+    yearlyViewsData = { year: thisYear, count: 0 };
+  }
+  yearlyViewsData.count++;
+  setCookie('yearlyViews', JSON.stringify(yearlyViewsData), 365);
+
+  return {
+      daily: dailyViewsData.count,
+      weekly: weeklyViewsData.count,
+      monthly: monthlyViewsData.count,
+      yearly: yearlyViewsData.count,
+      allTime: allTimeViews
+  };
+}
+
+function displayViews(views) {
+  document.getElementById('daily-views').textContent = views.daily;
+  document.getElementById('weekly-views').textContent = views.weekly;
+  document.getElementById('monthly-views').textContent = views.monthly;
+  document.getElementById('yearly-views').textContent = views.yearly;
+  document.getElementById('all-time-views').textContent = views.allTime;
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const views = trackView();
+  displayViews(views);
+});

--- a/styles/new-ui.css
+++ b/styles/new-ui.css
@@ -1237,3 +1237,52 @@ p {
     gap: 0.3rem;
   }
 }
+
+/* View Counter Styles */
+.view-counter {
+  display: flex;
+  justify-content: space-around;
+  margin-bottom: 20px;
+  width: 100%;
+  gap: 10px;
+}
+
+.glass-bubble {
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 20px;
+  padding: 10px;
+  text-align: center;
+  flex: 1;
+  backdrop-filter: blur(5px);
+  -webkit-backdrop-filter: blur(5px);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+.glass-bubble .count {
+  display: block;
+  font-size: clamp(1.2em, 4vw, 1.5em);
+  font-weight: bold;
+}
+
+.glass-bubble .label {
+  font-size: clamp(0.7em, 2.5vw, 0.8em);
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+@media (max-width: 520px) {
+  .view-counter {
+    flex-wrap: wrap;
+  }
+  .glass-bubble {
+    flex-basis: calc(50% - 10px);
+    margin-bottom: 10px;
+  }
+}
+
+@media (max-width: 380px) {
+  .glass-bubble {
+    flex-basis: 100%;
+  }
+}


### PR DESCRIPTION
This commit adds a view counter to the new UI, displaying the number of views for 'This day', 'This week', 'This Month', 'This Year', and 'All Time'.

The view counter is implemented using cookies to track views and is displayed in glass bubbles above the Vestige chart widget.

The following changes were made:
- Created `scripts/view-counter.js` to handle the view counting logic.
- Modified `new-ui.html` to include the view counter UI and the new script.
- Added CSS styles to `styles/new-ui.css` for the view counter.