### PR TITLE
fix: Correct view counter logic and hide on mobile

### DIFF
--- a/scripts/view-counter.js
+++ b/scripts/view-counter.js
@@ -42,10 +42,13 @@ function trackView() {
 
   // All-Time Views
   let allTimeViews = parseInt(getCookie('allTimeViews') || '0', 10);
-  if (!lastVisit) { // Only count new visitors for all-time
+  const returningVisitor = getCookie('returningVisitor');
+
+  if (!returningVisitor) {
       allTimeViews++;
+      setCookie('allTimeViews', allTimeViews, 365 * 10); // 10-year cookie for all-time count
+      setCookie('returningVisitor', 'true', 365 * 10); // 10-year cookie to mark as returning visitor
   }
-  setCookie('allTimeViews', allTimeViews, 365 * 10); // 10-year cookie
 
   // Daily Views
   let dailyViewsData = JSON.parse(getCookie('dailyViews') || '{}');

--- a/styles/new-ui.css
+++ b/styles/new-ui.css
@@ -1271,13 +1271,9 @@ p {
   color: rgba(255, 255, 255, 0.7);
 }
 
-@media (max-width: 520px) {
+@media (max-width: 700px) {
   .view-counter {
-    flex-wrap: wrap;
-  }
-  .glass-bubble {
-    flex-basis: calc(50% - 10px);
-    margin-bottom: 10px;
+    display: none;
   }
 }
 


### PR DESCRIPTION
This commit corrects the 'All Time' view counter to only count unique visitors and hides the view counter on mobile devices to prevent UI clutter.

- The 'All Time' view counter now uses a `returningVisitor` cookie to ensure it only increments once per visitor.
- The view counter is now hidden on screens smaller than 700px.