### PR TITLE
refactor: Change 'All Time' counter to total page views

### DIFF
--- a/scripts/view-counter.js
+++ b/scripts/view-counter.js
@@ -42,13 +42,8 @@ function trackView() {
 
   // All-Time Views
   let allTimeViews = parseInt(getCookie('allTimeViews') || '0', 10);
-  const returningVisitor = getCookie('returningVisitor');
-
-  if (!returningVisitor) {
-      allTimeViews++;
-      setCookie('allTimeViews', allTimeViews, 365 * 10); // 10-year cookie for all-time count
-      setCookie('returningVisitor', 'true', 365 * 10); // 10-year cookie to mark as returning visitor
-  }
+  allTimeViews++;
+  setCookie('allTimeViews', allTimeViews, 365 * 10); // 10-year cookie
 
   // Daily Views
   let dailyViewsData = JSON.parse(getCookie('dailyViews') || '{}');


### PR DESCRIPTION
This commit updates the 'All Time' view counter to show the total number of page views, rather than the number of unique visitors.

- The 'All Time' view counter now increments on every page view.